### PR TITLE
api.h: include <stddef.h> to define size_t

### DIFF
--- a/src/native/api.h
+++ b/src/native/api.h
@@ -3,6 +3,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+  
+#include <stddef.h>
 
 typedef llhttp__internal_t llhttp_t;
 typedef struct llhttp_settings_s llhttp_settings_t;

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -3,7 +3,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-  
 #include <stddef.h>
 
 typedef llhttp__internal_t llhttp_t;


### PR DESCRIPTION
try to suppress the compiler error as the below

````bash
# clang build/llhttp.h                                                                                                                                                 
build/llhttp.h:222:58: error: unknown type name 'size_t'
typedef int (*llhttp_data_cb)(llhttp_t*, const char *at, size_t length);
                                                         ^
build/llhttp.h:281:67: error: unknown type name 'size_t'
llhttp_errno_t llhttp_execute(llhttp_t* parser, const char* data, size_t len);
                                                                  ^
2 errors generated.
````