### PR TITLE
Fix bug that chunked encoding ends without last-chunk

### DIFF
--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -69,6 +69,7 @@ const NODES: ReadonlyArray<string> = [
 
   'chunk_size_start',
   'chunk_size',
+  'chunk_size2',
   'chunk_size_otherwise',
   'chunk_size_almost_done',
   'chunk_size_almost_done_lf',
@@ -594,7 +595,15 @@ export class HTTP {
     n('chunk_size')
       .select(HEX_MAP, this.mulAdd('content_length', {
         overflow: p.error(ERROR.INVALID_CHUNK_SIZE, 'Chunk size overflow'),
-        success: 'chunk_size',
+        success: 'chunk_size2',
+      }, { signed: false, base: 0x10 }))
+      .otherwise(p.error(ERROR.INVALID_CHUNK_SIZE,
+        'Invalid character in chunk size'));
+
+    n('chunk_size2')
+      .select(HEX_MAP, this.mulAdd('content_length', {
+        overflow: p.error(ERROR.INVALID_CHUNK_SIZE, 'Chunk size overflow'),
+        success: 'chunk_size2',
       }, { signed: false, base: 0x10 }))
       .otherwise(n('chunk_size_otherwise'));
 

--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -68,8 +68,8 @@ const NODES: ReadonlyArray<string> = [
   'headers_done',
 
   'chunk_size_start',
+  'chunk_size_digit',
   'chunk_size',
-  'chunk_size2',
   'chunk_size_otherwise',
   'chunk_size_almost_done',
   'chunk_size_almost_done_lf',
@@ -590,21 +590,20 @@ export class HTTP {
       .skipTo(n('eof'));
 
     n('chunk_size_start')
-      .otherwise(this.update('content_length', 0, 'chunk_size'));
+      .otherwise(this.update('content_length', 0, 'chunk_size_digit'));
 
-    n('chunk_size')
-      .select(HEX_MAP, this.mulAdd('content_length', {
-        overflow: p.error(ERROR.INVALID_CHUNK_SIZE, 'Chunk size overflow'),
-        success: 'chunk_size2',
-      }, { signed: false, base: 0x10 }))
+    const addContentLength = this.mulAdd('content_length', {
+      overflow: p.error(ERROR.INVALID_CHUNK_SIZE, 'Chunk size overflow'),
+      success: 'chunk_size',
+    }, { signed: false, base: 0x10 });
+
+    n('chunk_size_digit')
+      .select(HEX_MAP, addContentLength)
       .otherwise(p.error(ERROR.INVALID_CHUNK_SIZE,
         'Invalid character in chunk size'));
 
-    n('chunk_size2')
-      .select(HEX_MAP, this.mulAdd('content_length', {
-        overflow: p.error(ERROR.INVALID_CHUNK_SIZE, 'Chunk size overflow'),
-        success: 'chunk_size2',
-      }, { signed: false, base: 0x10 }))
+    n('chunk_size')
+      .select(HEX_MAP, addContentLength)
       .otherwise(n('chunk_size_otherwise'));
 
     n('chunk_size_otherwise')

--- a/test/request/transfer-encoding.md
+++ b/test/request/transfer-encoding.md
@@ -253,3 +253,28 @@ off=117 headers complete method=3 v=1/1 flags=20 content_length=5
 off=117 len=5 span[body]="World"
 off=122 message complete
 ```
+
+## Missing last-chunk
+
+<!-- meta={"type": "request"} -->
+```http
+PUT /url HTTP/1.1
+Transfer-Encoding: chunked
+
+3
+foo
+
+
+```
+
+```log
+off=0 message begin
+off=4 len=4 span[url]="/url"
+off=19 len=17 span[header_field]="Transfer-Encoding"
+off=38 len=7 span[header_value]="chunked"
+off=49 headers complete method=4 v=1/1 flags=8 content_length=0
+off=52 chunk header len=3
+off=52 len=3 span[body]="foo"
+off=57 chunk complete
+off=57 error code=12 reason="Invalid character in chunk size"
+```


### PR DESCRIPTION
This change fixes the bug that chunked encoding can end without seeing last-chunk.  More specifically, reading just extra `\r\n\r\n` persuades llhttp that chunked encoding finished.

Fixes #20 