### PR TITLE
constants: add `|` to list of allowed URL chars

### DIFF
--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -153,7 +153,7 @@ export const STRICT_URL_CHAR: CharList = ([
   ':', ';', '<', '=', '>',
   '@', '[', '\\', ']', '^', '_',
   '`',
-  '{', '}', '~',
+  '{', '|', '}', '~',
 ] as CharList).concat(ALPHANUM);
 
 export const URL_CHAR: CharList = STRICT_URL_CHAR

--- a/test/request/uri.md
+++ b/test/request/uri.md
@@ -67,6 +67,26 @@ off=51 headers complete method=1 v=1/1 flags=0 content_length=0
 off=51 message complete
 ```
 
+## Query URL with vertical bar character
+
+It should be allowed to have vertical bar symbol in URI: `|`.
+
+See: https://github.com/nodejs/node/issues/27584
+
+<!-- meta={"type": "request"} -->
+```http
+GET /test.cgi?query=| HTTP/1.1
+
+
+```
+
+```log
+off=0 message begin
+off=4 len=17 span[url]="/test.cgi?query=|"
+off=34 headers complete method=1 v=1/1 flags=0 content_length=0
+off=34 message complete
+```
+
 ## `host:port` terminated by a space
 
 <!-- meta={"type": "request"} -->


### PR DESCRIPTION
The vertical bar character `|` wasn't ported from http-parser during
rewrite. This commit introduces it back.

See: https://github.com/nodejs/http-parser/blob/5c17dad400e45c5a442a63f250fff2638d144682/http_parser.c#L275
See: https://github.com/nodejs/node/issues/27584