### PR TITLE
http: lenient parsing flag

### DIFF
--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -48,6 +48,7 @@ export enum FLAGS {
   CONTENT_LENGTH = 1 << 5,
   SKIPBODY = 1 << 6,
   TRAILING = 1 << 7,
+  LENIENT = 1 << 8,
 }
 
 export enum METHODS {

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -127,6 +127,15 @@ const char* llhttp_method_name(llhttp_method_t method) {
 }
 
 
+void llhttp_set_lenient(llhttp_t* parser, int enabled) {
+  if (enabled) {
+    parser->flags |= F_LENIENT;
+  } else {
+    parser->flags &= ~F_LENIENT;
+  }
+}
+
+
 /* Callbacks */
 
 

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -141,6 +141,18 @@ const char* llhttp_errno_name(llhttp_errno_t err);
 /* Returns textual name of HTTP method */
 const char* llhttp_method_name(llhttp_method_t method);
 
+
+/* Enables/disables lenient header value parsing (disabled by default).
+ *
+ * Lenient parsing disables header value token checks, extending llhttp's
+ * protocol support to highly non-compliant clients/server. No
+ * `HPE_INVALID_HEADER_TOKEN` will be raised for incorrect header values when
+ * lenient parsing is "on".
+ *
+ * **(USE AT YOUR OWN RISK)**
+ */
+void llhttp_set_lenient(llhttp_t* parser, int enabled);
+
 #ifdef __cplusplus
 }  /* extern "C" */
 #endif

--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -57,6 +57,12 @@ void llhttp__test_init_response(llparse_t* s) {
 }
 
 
+void llhttp__test_init_request_lenient(llparse_t* s) {
+  llhttp__test_init_request(s);
+  s->flags |= F_LENIENT;
+}
+
+
 void llhttp__test_finish(llparse_t* s) {
   llparse__print(NULL, NULL, "finish=%d", s->finish);
 }

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -8,8 +8,8 @@ import * as path from 'path';
 
 import * as llhttp from '../../src/llhttp';
 
-export type TestType = 'request' | 'response' | 'request-finish' |
-  'response-finish' | 'none' | 'url';
+export type TestType = 'request' | 'response' | 'request-lenient' |
+  'request-finish' | 'response-finish' | 'none' | 'url';
 
 export { FixtureResult };
 
@@ -58,8 +58,9 @@ export function build(llparse: LLParse, node: any, outFile: string,
   }
 
   const extra = options.extra === undefined ? [] : options.extra.slice();
-  if (ty === 'request' || ty === 'response') {
-    extra.push(`-DLLPARSE__TEST_INIT=llhttp__test_init_${ty}`);
+  if (ty === 'request' || ty === 'response' || ty === 'request-lenient') {
+    extra.push(
+      `-DLLPARSE__TEST_INIT=llhttp__test_init_${ty.replace(/-/g, '_')}`);
   } else if (ty === 'request-finish' || ty === 'response-finish') {
     if (ty === 'request-finish') {
       extra.push('-DLLPARSE__TEST_INIT=llhttp__test_init_request');

--- a/test/md-test.ts
+++ b/test/md-test.ts
@@ -78,6 +78,7 @@ const http: IFixtureMap = {
     'none': buildMode('loose', 'none'),
     'request': buildMode('loose', 'request'),
     'request-finish': buildMode('loose', 'request-finish'),
+    'request-lenient': buildMode('loose', 'request-lenient'),
     'response': buildMode('loose', 'response'),
     'response-finish': buildMode('loose', 'response-finish'),
     'url': buildMode('loose', 'url'),
@@ -86,6 +87,7 @@ const http: IFixtureMap = {
     'none': buildMode('strict', 'none'),
     'request': buildMode('strict', 'request'),
     'request-finish': buildMode('strict', 'request-finish'),
+    'request-lenient': buildMode('strict', 'request-lenient'),
     'response': buildMode('strict', 'response'),
     'response-finish': buildMode('strict', 'response-finish'),
     'url': buildMode('strict', 'url'),
@@ -143,6 +145,8 @@ function run(name: string): void {
           types.push('response');
         } else if (meta.type === 'request-only') {
           types = [ 'request' ];
+        } else if (meta.type === 'request-lenient') {
+          types = [ 'request-lenient' ];
         } else if (meta.type === 'response-only') {
           types = [ 'response' ];
         } else if (meta.type === 'request-finish') {
@@ -231,6 +235,7 @@ function run(name: string): void {
 }
 
 run('request/sample');
+run('request/lenient');
 run('request/method');
 run('request/uri');
 run('request/connection');

--- a/test/request/lenient.md
+++ b/test/request/lenient.md
@@ -1,0 +1,41 @@
+Lenient header value parsing
+============================
+
+Parsing with header value token checks off.
+
+## Header value with lenient
+
+<!-- meta={"type": "request-lenient"} -->
+```http
+GET /url HTTP/1.1
+Header1: \f
+
+
+```
+
+```log
+off=0 message begin
+off=4 len=4 span[url]="/url"
+off=19 len=7 span[header_field]="Header1"
+off=28 len=1 span[header_value]="\f"
+off=33 headers complete method=1 v=1/1 flags=100 content_length=0
+off=33 message complete
+```
+
+## Header value without lenient
+
+<!-- meta={"type": "request"} -->
+```http
+GET /url HTTP/1.1
+Header1: \f
+
+
+
+```
+
+```log
+off=0 message begin
+off=4 len=4 span[url]="/url"
+off=19 len=7 span[header_field]="Header1"
+off=28 error code=10 reason="Invalid header value char"
+```


### PR DESCRIPTION
Introduce `llhttp_set_lenient` API method for enabling/disabling lenient
parsing mode for header value. With lenient parsing on - no token check
would be performed on the header value.

This mode was originally introduced to http-parser in
nodejs/http-parser@e2e467b in
order to provide a fallback mode for less compliant clients/servers.

---

See: https://github.com/nodejs/node/pull/30222#issuecomment-549087282

cc @addaleax @nodejs/http 