### PR TITLE
http: keep `F_LENIENT` between messages

### DIFF
--- a/src/native/http.c
+++ b/src/native/http.c
@@ -74,8 +74,10 @@ int llhttp__after_message_complete(llhttp_t* parser, const char* p,
   int should_keep_alive;
 
   should_keep_alive = llhttp_should_keep_alive(parser);
-  parser->flags = 0;
   parser->finish = HTTP_FINISH_SAFE;
+
+  /* Keep `F_LENIENT` flag between messages, but reset every other flag */
+  parser->flags &= F_LENIENT;
 
   /* NOTE: this is ignored in loose parsing mode */
   return should_keep_alive;

--- a/test/request/lenient.md
+++ b/test/request/lenient.md
@@ -22,6 +22,35 @@ off=33 headers complete method=1 v=1/1 flags=100 content_length=0
 off=33 message complete
 ```
 
+## Second request header value with lenient
+
+<!-- meta={"type": "request-lenient"} -->
+```http
+GET /url HTTP/1.1
+Header1: Okay
+
+
+GET /url HTTP/1.1
+Header1: \f
+
+
+```
+
+```log
+off=0 message begin
+off=4 len=4 span[url]="/url"
+off=19 len=7 span[header_field]="Header1"
+off=28 len=4 span[header_value]="Okay"
+off=36 headers complete method=1 v=1/1 flags=100 content_length=0
+off=36 message complete
+off=38 message begin
+off=42 len=4 span[url]="/url"
+off=57 len=7 span[header_field]="Header1"
+off=66 len=1 span[header_value]="\f"
+off=71 headers complete method=1 v=1/1 flags=100 content_length=0
+off=71 message complete
+```
+
 ## Header value without lenient
 
 <!-- meta={"type": "request"} -->


### PR DESCRIPTION
`F_LENIENT` flag should not be reset along with the other flags when
starting parsing a new message. This setting should remain on for the
lifetime of the parser or until `llhttp_set_lenient(..., 0)`.

cc @nodejs/http @addaleax @bnoordhuis