### PR TITLE
Port recent commits from http-parser

### DIFF
--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -400,10 +400,16 @@ export class HTTP {
         n('header_value_discard_lws'));
     }
 
+    const emptyContentLengthError = p.error(
+      ERROR.INVALID_CONTENT_LENGTH, 'Empty Content-Length');
+    const checkContentLengthEmptiness = this.load('header_state', {
+      [HEADER_STATE.CONTENT_LENGTH]: emptyContentLengthError,
+    }, this.setHeaderFlags(
+      this.emptySpan(span.headerValue, 'header_field_start')));
+
     n('header_value_discard_lws')
       .match([ ' ', '\t' ], n('header_value_discard_ws'))
-      .otherwise(this.setHeaderFlags(
-        this.emptySpan(span.headerValue, 'header_field_start')));
+      .otherwise(checkContentLengthEmptiness);
 
     n('header_value_start')
       .otherwise(this.load('header_state', {

--- a/test/request/content-length.md
+++ b/test/request/content-length.md
@@ -182,3 +182,20 @@ off=17 len=14 span[header_field]="Content-Length"
 off=33 len=3 span[header_value]="13 "
 off=36 error code=11 reason="Invalid character in Content-Length"
 ```
+
+### Empty `Content-Length`
+
+<!-- meta={"type": "request"} -->
+```http
+POST / HTTP/1.1
+Content-Length:
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=17 len=14 span[header_field]="Content-Length"
+off=34 error code=11 reason="Empty Content-Length"
+```

--- a/test/request/content-length.md
+++ b/test/request/content-length.md
@@ -183,6 +183,41 @@ off=33 len=3 span[header_value]="13 "
 off=36 error code=11 reason="Invalid character in Content-Length"
 ```
 
+### Spaces in `Content-Length` #4 (surrounding and on next line)
+
+<!-- meta={"type": "request"} -->
+```http
+POST / HTTP/1.1
+Content-Length:  42
+ 
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=17 len=14 span[header_field]="Content-Length"
+off=34 len=2 span[header_value]="42"
+```
+
+### Spaces in `Content-Length` #5 (surrounding and with text on next line)
+
+<!-- meta={"type": "request"} -->
+```http
+POST / HTTP/1.1
+Content-Length:  42
+ Hello world!
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=17 len=14 span[header_field]="Content-Length"
+off=34 len=2 span[header_value]="42"
+off=39 error code=11 reason="Invalid character in Content-Length"
+```
+
 ### Empty `Content-Length`
 
 <!-- meta={"type": "request"} -->

--- a/test/request/content-length.md
+++ b/test/request/content-length.md
@@ -129,8 +129,7 @@ off=72 len=5 span[body]="HELLO"
 off=77 message complete
 ```
 
-
-## `Content-Length` with spaces after the value
+## Spaces in `Content-Length` (surrounding)
 
 <!-- meta={"type": "request"} -->
 ```http
@@ -146,4 +145,40 @@ off=5 len=1 span[url]="/"
 off=17 len=14 span[header_field]="Content-Length"
 off=34 len=3 span[header_value]="42 "
 off=41 headers complete method=3 v=1/1 flags=20 content_length=42
+```
+
+### Spaces in `Content-Length` #2
+
+<!-- meta={"type": "request"} -->
+```http
+POST / HTTP/1.1
+Content-Length: 4 2
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=17 len=14 span[header_field]="Content-Length"
+off=33 len=2 span[header_value]="4 "
+off=35 error code=11 reason="Invalid character in Content-Length"
+```
+
+### Spaces in `Content-Length` #3
+
+<!-- meta={"type": "request"} -->
+```http
+POST / HTTP/1.1
+Content-Length: 13 37
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=17 len=14 span[header_field]="Content-Length"
+off=33 len=3 span[header_value]="13 "
+off=36 error code=11 reason="Invalid character in Content-Length"
 ```

--- a/test/request/invalid.md
+++ b/test/request/invalid.md
@@ -1,42 +1,6 @@
 Invalid requests
 ================
 
-### Spaces in Content-Length
-
-<!-- meta={"type": "request"} -->
-```http
-POST / HTTP/1.1
-Content-Length: 4 2
-
-
-```
-
-```log
-off=0 message begin
-off=5 len=1 span[url]="/"
-off=17 len=14 span[header_field]="Content-Length"
-off=33 len=2 span[header_value]="4 "
-off=35 error code=11 reason="Invalid character in Content-Length"
-```
-
-### Spaces in Content-Length #2
-
-<!-- meta={"type": "request"} -->
-```http
-POST / HTTP/1.1
-Content-Length: 13 37
-
-
-```
-
-```log
-off=0 message begin
-off=5 len=1 span[url]="/"
-off=17 len=14 span[header_field]="Content-Length"
-off=33 len=3 span[header_value]="13 "
-off=36 error code=11 reason="Invalid character in Content-Length"
-```
-
 ### ICE protocol and GET method
 
 <!-- meta={"type": "request"} -->


### PR DESCRIPTION
Issue #12 

https://github.com/nodejs/http-parser/commit/01da95f already in tests, but I moved them from `invalid.md` to `content-length.md`
https://github.com/nodejs/http-parser/commit/3502589 [x] added
https://github.com/nodejs/http-parser/commit/cd88eef [x] need improvements

Early feedback appreciated. Is this OK that `mdgator` require extra newline? For new test I was need `\r\n\r\n`, but with `mdgator` I was able receive it only with 2 empty lines (which give 3 x `\r\n`, right?).

Whole project (and deps) is just WOW, I do not understand how it's possible to create it haha. Spent few hours for adding simple 5 lines.