### PR TITLE
Speedup tests execution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -517,6 +517,12 @@
         "path-exists": "^3.0.0"
       }
     },
+    "make-concurrent": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/make-concurrent/-/make-concurrent-5.3.0.tgz",
+      "integrity": "sha512-8si1KzXm7DiUXSbeOPliY9MrNVFGaEEgKZNctxz9FM3Ztx/cb5qiUazD/8WurKCJL05/zizZHBXYdjXRNAvtFA==",
+      "dev": true
+    },
     "make-error": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf lib && rm -rf test/tmp",
     "prepare": "npm run clean && npm run build-ts",
     "lint": "tslint -c tslint.json bin/*.ts src/*.ts src/**/*.ts test/*.ts test/**/*.ts",
-    "mocha": "mocha --timeout=10000 -r ts-node/register/type-check --reporter progress test/*-test.ts",
+    "mocha": "mocha --timeout=30000 -r ts-node/register/type-check --reporter progress test/*-test.ts",
     "test": "npm run mocha && npm run lint",
     "postversion": "TAG=`node -e \"process.stdout.write(require('./package').version)\"` make -B postversion"
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/node": "^10.17.13",
     "llparse-dot": "^1.0.1",
     "llparse-test-fixture": "^3.3.2",
+    "make-concurrent": "^5.3.0",
     "mdgator": "^1.1.2",
     "mocha": "^5.2.0",
     "ts-node": "^7.0.1",

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -33,7 +33,8 @@ const fixtures = new Fixture({
     '-include', CHEADERS_FILE,
     path.join(__dirname, 'extra.c'),
   ],
-  maxParallel: process.env.LLPARSE_DEBUG ? 1 : undefined,
+  // faster check whole input instead split it to chunks, so 1 in anycase
+  maxParallel: process.env.LLPARSE_DEBUG ? 1 : 1,
 });
 
 const cache: Map<any, ICompilerResult> = new Map();

--- a/test/md-test.ts
+++ b/test/md-test.ts
@@ -105,9 +105,7 @@ const runJobInQueue = makeConcurrent(jobFunction, { concurrency: maxParallel });
 async function jobFunction(fixture: FixtureResult, input: string,
                            expected: ReadonlyArray<string | RegExp>,
                            options: { noScan: boolean }): Promise<void> {
-  const p = fixture.check(input, expected, options);
-  p.catch(() => null); // skip unhandledRejection for this promise
-  return p;
+  return fixture.check(input, expected, options);
 }
 
 function run(name: string): void {
@@ -122,6 +120,7 @@ function run(name: string): void {
 
     const jobOptions = { noScan: meta.noScan === true };
     const job = runJobInQueue(http[mode][ty], input, expected, jobOptions);
+    job.catch(() => null); // skip unhandledRejection for this promise
     it(`should pass in mode="${mode}" and for type="${ty}"`, async () => job);
   }
 


### PR DESCRIPTION
On my laptop with 8 cpus:

Without: `1m16.364s`
With: `0m22.755s`