### PR TITLE
ci: change travis to gh actions + Windows support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,114 @@
+name: CI
+
+on: [push, pull_request]
+
+env:
+  CI: true
+
+jobs:
+  build:
+    name: Build libllhttp.a
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Install clang for Windows
+        if: runner.os == 'Windows'
+        run: |
+          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+          scoop install llvm --global
+
+          # Scoop modifies the PATH so we make the modified PATH global.
+          echo "::set-env name=PATH::$env:PATH"
+
+      - name: Fetch code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      # Skip macOS & Windows, cache there is slower
+      - name: Restore node_modules cache for Linux
+        uses: actions/cache@v1
+        if: runner.os == 'Linux'
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Build libllhttp.a
+        shell: bash
+        run: make build/libllhttp.a
+
+  test:
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Install clang for Windows
+        if: runner.os == 'Windows'
+        run: |
+          Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+          scoop install llvm --global
+
+          # Scoop modifies the PATH so we make the modified PATH global.
+          echo "::set-env name=PATH::$env:PATH"
+
+      - name: Fetch code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      # Skip macOS & Windows, cache there is slower
+      - name: Restore node_modules cache for Linux
+        uses: actions/cache@v1
+        if: runner.os == 'Linux'
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      # Custom script, because progress looks not good in CI
+      - name: Run tests
+        env:
+          CFLAGS: -O0
+        run: npx mocha --timeout 30000 -r ts-node/register/type-check test/*-test.ts
+
+  lint:
+    name: Run TSLint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch code
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: Restore node_modules cache
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Run lint command
+        run: npm run lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           echo "::set-env name=PATH::$env:PATH"
 
       - name: Fetch code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
@@ -67,7 +67,7 @@ jobs:
           echo "::set-env name=PATH::$env:PATH"
 
       - name: Fetch code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fetch code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "stable"
-script:
-  CFLAGS="-O0" npm test

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,6 @@ postversion: release
 	git checkout master
 
 generate:
-	./bin/generate.ts
+	npx ts-node bin/generate.ts
 
 .PHONY: all generate clean release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # llhttp
-[![Build Status](https://secure.travis-ci.org/nodejs/llhttp.svg)](http://travis-ci.org/nodejs/llhttp)
 
 Port of [http_parser][0] to [llparse][1].
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,9 +497,9 @@
       }
     },
     "llparse-test-fixture": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/llparse-test-fixture/-/llparse-test-fixture-3.3.2.tgz",
-      "integrity": "sha512-HVdP6T1QNdlsq1ku7jr9JmdPTyxHzpP25Csy8S99pIoBPVYXV5FJQJNjpjRdLJav9hoS1kA7vVGOKOmqFzMEqQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/llparse-test-fixture/-/llparse-test-fixture-3.3.3.tgz",
+      "integrity": "sha512-1qsjqF6m6fAYevFIBeEItUIHHHYnsmdGsijEFR/7fasq/hMKnTKFRigUjcAc9V36HJMUj3raExR3lrNp0mIFEw==",
       "dev": true,
       "requires": {
         "esm": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/mocha": "^5.2.7",
     "@types/node": "^10.17.13",
     "llparse-dot": "^1.0.1",
-    "llparse-test-fixture": "^3.3.2",
+    "llparse-test-fixture": "^3.3.3",
     "mdgator": "^1.1.2",
     "mocha": "^5.2.0",
     "ts-node": "^7.0.1",

--- a/test/md-test.ts
+++ b/test/md-test.ts
@@ -200,6 +200,17 @@ function run(name: string): void {
         return vm.runInNewContext(code) + '';
       });
 
+      // Escape first symbol `\r` or `\n`, `|`, `&` for Windows
+      if (process.platform === 'win32') {
+        const firstByte = Buffer.from(input)[0];
+        if (firstByte === 0x0a || firstByte === 0x0d) {
+          input = '\\' + input;
+        }
+
+        input = input.replace(/\|/g, '^|');
+        input = input.replace(/&/g, '^&');
+      }
+
       // Replace escaped tabs/form-feed in expected too
       expected = expected.replace(/\\t/g, '\t');
       expected = expected.replace(/\\f/g, '\f');


### PR DESCRIPTION
Why GitHub Actions? Because support 3 platform at one place.

Are you interesting in running tests on Windows? (will need extra efforts in `llparse-test-fixtures` for fixing `sys/time.h` header)

CI files can be applied to other llhttp repos.

CI status: https://github.com/fanatid/llhttp/actions