### PR TITLE
generate: fix -S invalid option under Ubuntu 16.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ postversion: release
 	git checkout master
 
 generate:
-	./bin/generate.ts
+	npm run build
 
 install: build/libllhttp.a
 	$(INSTALL) build/llhttp.h $(DESTDIR)$(INCLUDEDIR)/llhttp.h


### PR DESCRIPTION
The `env` command don't have -S option under Ubuntu 16.04.

```
$ make
./bin/generate.ts
/usr/bin/env: invalid option -- 'S'
Try '/usr/bin/env --help' for more information.
Makefile:62: recipe for target 'generate' failed
make: *** [generate] Error 125
```