### PR TITLE
Handle custom methods and protocols

### DIFF
--- a/src/llhttp/c-headers.ts
+++ b/src/llhttp/c-headers.ts
@@ -17,7 +17,6 @@ export class CHeaders {
     res += '\n';
 
     const errorMap = enumToMap(constants.ERROR);
-    const methodMap = enumToMap(constants.METHODS);
 
     res += this.buildEnum('llhttp_errno', 'HPE', errorMap);
     res += '\n';
@@ -29,14 +28,10 @@ export class CHeaders {
     res += '\n';
     res += this.buildEnum('llhttp_finish', 'HTTP_FINISH',
       enumToMap(constants.FINISH));
-    res += '\n';
-    res += this.buildEnum('llhttp_method', 'HTTP', methodMap);
 
     res += '\n';
 
     res += this.buildMap('HTTP_ERRNO', errorMap);
-    res += '\n';
-    res += this.buildMap('HTTP_METHOD', methodMap);
     res += '\n';
 
     res += '\n';

--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -51,63 +51,8 @@ export enum FLAGS {
   TRAILING = 1 << 7,
   LENIENT = 1 << 8,
   TRANSFER_ENCODING = 1 << 9,
+  METHOD_CONNECT = 1 << 10,
 }
-
-export enum METHODS {
-  DELETE = 0,
-  GET = 1,
-  HEAD = 2,
-  POST = 3,
-  PUT = 4,
-  /* pathological */
-  CONNECT = 5,
-  OPTIONS = 6,
-  TRACE = 7,
-  /* WebDAV */
-  COPY = 8,
-  LOCK = 9,
-  MKCOL = 10,
-  MOVE = 11,
-  PROPFIND = 12,
-  PROPPATCH = 13,
-  SEARCH = 14,
-  UNLOCK = 15,
-  BIND = 16,
-  REBIND = 17,
-  UNBIND = 18,
-  ACL = 19,
-  /* subversion */
-  REPORT = 20,
-  MKACTIVITY = 21,
-  CHECKOUT = 22,
-  MERGE = 23,
-  /* upnp */
-  'M-SEARCH' = 24,
-  NOTIFY = 25,
-  SUBSCRIBE = 26,
-  UNSUBSCRIBE = 27,
-  /* RFC-5789 */
-  PATCH = 28,
-  PURGE = 29,
-  /* CalDAV */
-  MKCALENDAR = 30,
-  /* RFC-2068, section 19.6.1.2 */
-  LINK = 31,
-  UNLINK = 32,
-  /* icecast */
-  SOURCE = 33,
-  /* RFC-7540, section 11.6 */
-  PRI = 34,
-}
-
-export const METHOD_MAP = enumToMap(METHODS);
-export const H_METHOD_MAP: IEnumMap = {};
-
-Object.keys(METHOD_MAP).forEach((key) => {
-  if (/^H/.test(key)) {
-    H_METHOD_MAP[key] = METHOD_MAP[key];
-  }
-});
 
 export enum FINISH {
   SAFE = 0,

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -117,16 +117,6 @@ const char* llhttp_errno_name(llhttp_errno_t err) {
 }
 
 
-const char* llhttp_method_name(llhttp_method_t method) {
-#define HTTP_METHOD_GEN(NUM, NAME, STRING) case HTTP_##NAME: return #STRING;
-  switch (method) {
-    HTTP_METHOD_MAP(HTTP_METHOD_GEN)
-    default: abort();
-  }
-#undef HTTP_METHOD_GEN
-}
-
-
 void llhttp_set_lenient(llhttp_t* parser, int enabled) {
   if (enabled) {
     parser->flags |= F_LENIENT;
@@ -156,6 +146,20 @@ int llhttp__on_url(llhttp_t* s, const char* p, const char* endp) {
 int llhttp__on_status(llhttp_t* s, const char* p, const char* endp) {
   int err;
   CALLBACK_MAYBE(s, on_status, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_method(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_method, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_protocol(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_protocol, s, p, endp - p);
   return err;
 }
 

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -17,6 +17,8 @@ struct llhttp_settings_s {
 
   llhttp_data_cb on_url;
   llhttp_data_cb on_status;
+  llhttp_data_cb on_method;
+  llhttp_data_cb on_protocol;
   llhttp_data_cb on_header_field;
   llhttp_data_cb on_header_value;
 
@@ -137,9 +139,6 @@ const char* llhttp_get_error_pos(const llhttp_t* parser);
 
 /* Returns textual name of error code */
 const char* llhttp_errno_name(llhttp_errno_t err);
-
-/* Returns textual name of HTTP method */
-const char* llhttp_method_name(llhttp_method_t method);
 
 
 /* Enables/disables lenient header value parsing (disabled by default).

--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -75,6 +75,20 @@ int llhttp__on_status(llparse_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_method(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+  return llparse__print_span("method", p, endp);
+}
+
+
+int llhttp__on_protocol(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+  return llparse__print_span("protocol", p, endp);
+}
+
+
 int llhttp__on_header_field(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
@@ -95,8 +109,8 @@ int llhttp__on_headers_complete(llparse_t* s, const char* p, const char* endp) {
 
   if (s->type == HTTP_REQUEST) {
     llparse__print(p, endp,
-        "headers complete method=%d v=%d/%d flags=%x content_length=%llu",
-        s->method, s->http_major, s->http_minor, s->flags, s->content_length);
+        "headers complete v=%d/%d flags=%x content_length=%llu",
+        s->http_major, s->http_minor, s->flags, s->content_length);
   } else if (s->type == HTTP_RESPONSE) {
     llparse__print(p, endp,
         "headers complete status=%d v=%d/%d flags=%x content_length=%llu",

--- a/test/request/connection.md
+++ b/test/request/connection.md
@@ -15,10 +15,12 @@ Connection: keep-alive
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=10 span[header_field]="Connection"
 off=31 len=10 span[header_value]="keep-alive"
-off=45 headers complete method=4 v=1/1 flags=1 content_length=0
+off=45 headers complete v=1/1 flags=1 content_length=0
 off=45 message complete
 ```
 
@@ -37,16 +39,20 @@ Connection: keep-alive
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=10 span[header_field]="Connection"
 off=31 len=10 span[header_value]="keep-alive"
-off=45 headers complete method=4 v=1/1 flags=1 content_length=0
+off=45 headers complete v=1/1 flags=1 content_length=0
 off=45 message complete
 off=45 message begin
+off=45 len=3 span[method]="PUT"
 off=49 len=4 span[url]="/url"
+off=54 len=4 span[protocol]="HTTP"
 off=64 len=10 span[header_field]="Connection"
 off=76 len=10 span[header_value]="keep-alive"
-off=90 headers complete method=4 v=1/1 flags=1 content_length=0
+off=90 headers complete v=1/1 flags=1 content_length=0
 off=90 message complete
 ```
 
@@ -63,8 +69,10 @@ PUT /url HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
-off=21 headers complete method=4 v=1/0 flags=0 content_length=0
+off=9 len=4 span[protocol]="HTTP"
+off=21 headers complete v=1/0 flags=0 content_length=0
 off=21 message complete
 off=22 error code=5 reason="Data after `Connection: close`"
 ```
@@ -87,16 +95,20 @@ Transfer-Encoding: chunked
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=1 span[header_value]="0"
-off=40 headers complete method=4 v=1/0 flags=20 content_length=0
+off=40 headers complete v=1/0 flags=20 content_length=0
 off=40 message complete
 off=40 message begin
+off=40 len=3 span[method]="PUT"
 off=44 len=4 span[url]="/url"
+off=49 len=4 span[protocol]="HTTP"
 off=59 len=17 span[header_field]="Transfer-Encoding"
 off=78 len=7 span[header_value]="chunked"
-off=89 headers complete method=4 v=1/1 flags=208 content_length=0
+off=89 headers complete v=1/1 flags=208 content_length=0
 ```
 
 ### CRLF between requests, implicit `keep-alive`
@@ -116,18 +128,22 @@ _Note the trailing CRLF above_
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=4 span[header_field]="Host"
 off=23 len=15 span[header_value]="www.example.com"
 off=40 len=12 span[header_field]="Content-Type"
 off=54 len=33 span[header_value]="application/x-www-form-urlencoded"
 off=89 len=14 span[header_field]="Content-Length"
 off=105 len=1 span[header_value]="4"
-off=110 headers complete method=3 v=1/1 flags=20 content_length=4
+off=110 headers complete v=1/1 flags=20 content_length=4
 off=110 len=4 span[body]="q=42"
 off=114 message complete
 off=118 message begin
+off=118 len=3 span[method]="GET"
 off=122 len=1 span[url]="/"
+off=124 len=4 span[protocol]="HTTP"
 ```
 
 ## `close`
@@ -144,10 +160,12 @@ Connection: close
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=10 span[header_field]="Connection"
 off=31 len=5 span[header_value]="close"
-off=40 headers complete method=4 v=1/1 flags=2 content_length=0
+off=40 headers complete v=1/1 flags=2 content_length=0
 off=40 message complete
 ```
 
@@ -171,7 +189,9 @@ _Note the trailing CRLF above_
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=4 span[header_field]="Host"
 off=23 len=15 span[header_value]="www.example.com"
 off=40 len=12 span[header_field]="Content-Type"
@@ -180,7 +200,7 @@ off=89 len=14 span[header_field]="Content-Length"
 off=105 len=1 span[header_value]="4"
 off=108 len=10 span[header_field]="Connection"
 off=120 len=5 span[header_value]="close"
-off=129 headers complete method=3 v=1/1 flags=22 content_length=4
+off=129 headers complete v=1/1 flags=22 content_length=4
 off=129 len=4 span[body]="q=42"
 off=133 message complete
 off=138 error code=5 reason="Data after `Connection: close`"
@@ -206,7 +226,9 @@ _Note the trailing CRLF above_
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=4 span[header_field]="Host"
 off=23 len=15 span[header_value]="www.example.com"
 off=40 len=12 span[header_field]="Content-Type"
@@ -215,11 +237,13 @@ off=89 len=14 span[header_field]="Content-Length"
 off=105 len=1 span[header_value]="4"
 off=108 len=10 span[header_field]="Connection"
 off=120 len=5 span[header_value]="close"
-off=129 headers complete method=3 v=1/1 flags=22 content_length=4
+off=129 headers complete v=1/1 flags=22 content_length=4
 off=129 len=4 span[body]="q=42"
 off=133 message complete
 off=137 message begin
+off=137 len=3 span[method]="GET"
 off=141 len=1 span[url]="/"
+off=143 len=4 span[protocol]="HTTP"
 ```
 
 ## Parsing multiple tokens
@@ -236,10 +260,12 @@ Connection: close, token, upgrade, token, keep-alive
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=10 span[header_field]="Connection"
 off=31 len=40 span[header_value]="close, token, upgrade, token, keep-alive"
-off=75 headers complete method=4 v=1/1 flags=7 content_length=0
+off=75 headers complete v=1/1 flags=7 content_length=0
 off=75 message complete
 ```
 
@@ -262,7 +288,9 @@ Hot diggity dogg
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=5 span[url]="/demo"
+off=10 len=4 span[protocol]="HTTP"
 off=20 len=4 span[header_field]="Host"
 off=26 len=11 span[header_value]="example.com"
 off=39 len=10 span[header_field]="Connection"
@@ -278,7 +306,7 @@ off=178 len=18 span[header_field]="Sec-WebSocket-Key1"
 off=198 len=20 span[header_value]="4 @1  46546xW%0l 1 5"
 off=220 len=6 span[header_field]="Origin"
 off=228 len=18 span[header_value]="http://example.com"
-off=250 headers complete method=1 v=1/1 flags=15 content_length=0
+off=250 headers complete v=1/1 flags=15 content_length=0
 off=250 message complete
 off=250 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -296,12 +324,14 @@ Hot diggity dogg
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=5 span[url]="/demo"
+off=10 len=4 span[protocol]="HTTP"
 off=20 len=10 span[header_field]="Connection"
 off=32 len=19 span[header_value]="keep-alive, upgrade"
 off=53 len=7 span[header_field]="Upgrade"
 off=62 len=9 span[header_value]="WebSocket"
-off=75 headers complete method=1 v=1/1 flags=15 content_length=0
+off=75 headers complete v=1/1 flags=15 content_length=0
 off=75 message complete
 off=75 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -319,13 +349,15 @@ Hot diggity dogg
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=5 span[url]="/demo"
+off=10 len=4 span[protocol]="HTTP"
 off=20 len=10 span[header_field]="Connection"
 off=32 len=12 span[header_value]="keep-alive, "
 off=46 len=8 span[header_value]=" upgrade"
 off=56 len=7 span[header_field]="Upgrade"
 off=65 len=9 span[header_value]="WebSocket"
-off=78 headers complete method=1 v=1/1 flags=15 content_length=0
+off=78 headers complete v=1/1 flags=15 content_length=0
 off=78 message complete
 off=78 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -345,12 +377,14 @@ Upgrade: ws
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=10 span[header_field]="Connection"
 off=31 len=7 span[header_value]="upgrade"
 off=40 len=7 span[header_field]="Upgrade"
 off=49 len=2 span[header_value]="ws"
-off=55 headers complete method=4 v=1/1 flags=14 content_length=0
+off=55 headers complete v=1/1 flags=14 content_length=0
 off=55 message complete
 off=55 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -369,14 +403,16 @@ abcdefgh
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=10 span[header_field]="Connection"
 off=31 len=7 span[header_value]="upgrade"
 off=40 len=14 span[header_field]="Content-Length"
 off=56 len=1 span[header_value]="4"
 off=59 len=7 span[header_field]="Upgrade"
 off=68 len=2 span[header_value]="ws"
-off=74 headers complete method=4 v=1/1 flags=34 content_length=4
+off=74 headers complete v=1/1 flags=34 content_length=4
 off=74 len=4 span[body]="abcd"
 off=78 message complete
 off=78 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -400,7 +436,9 @@ Hot diggity dogg
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=5 span[url]="/demo"
+off=10 len=4 span[protocol]="HTTP"
 off=20 len=4 span[header_field]="Host"
 off=26 len=11 span[header_value]="example.com"
 off=39 len=10 span[header_field]="Connection"
@@ -415,7 +453,7 @@ off=152 len=18 span[header_field]="Sec-WebSocket-Key1"
 off=172 len=20 span[header_value]="4 @1  46546xW%0l 1 5"
 off=194 len=6 span[header_field]="Origin"
 off=202 len=18 span[header_value]="http://example.com"
-off=224 headers complete method=1 v=1/1 flags=14 content_length=0
+off=224 headers complete v=1/1 flags=14 content_length=0
 off=224 message complete
 off=224 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -436,7 +474,9 @@ Hot diggity dogg
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=5 span[url]="/demo"
+off=11 len=4 span[protocol]="HTTP"
 off=21 len=4 span[header_field]="Host"
 off=27 len=11 span[header_value]="example.com"
 off=40 len=10 span[header_field]="Connection"
@@ -445,7 +485,7 @@ off=61 len=7 span[header_field]="Upgrade"
 off=70 len=8 span[header_value]="HTTP/2.0"
 off=80 len=14 span[header_field]="Content-Length"
 off=96 len=2 span[header_value]="15"
-off=102 headers complete method=3 v=1/1 flags=34 content_length=15
+off=102 headers complete v=1/1 flags=34 content_length=15
 off=102 len=15 span[body]="sweet post body"
 off=117 message complete
 off=117 error code=22 reason="Pause on CONNECT/Upgrade"

--- a/test/request/content-length.md
+++ b/test/request/content-length.md
@@ -13,10 +13,12 @@ abc
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=3 span[header_value]="003"
-off=42 headers complete method=4 v=1/1 flags=20 content_length=3
+off=42 headers complete v=1/1 flags=20 content_length=3
 off=42 len=3 span[body]="abc"
 off=45 message complete
 ```
@@ -42,12 +44,14 @@ abc
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=3 span[header_value]="003"
 off=40 len=4 span[header_field]="Ohai"
 off=46 len=5 span[header_value]="world"
-off=55 headers complete method=4 v=1/1 flags=20 content_length=3
+off=55 headers complete v=1/1 flags=20 content_length=3
 off=55 len=3 span[body]="abc"
 off=58 message complete
 ```
@@ -63,7 +67,9 @@ Content-Length: 1000000000000000000000
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=21 span[header_value]="100000000000000000000"
 off=56 error code=11 reason="Content-Length overflow"
@@ -81,7 +87,9 @@ Content-Length: 2
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=1 span[header_value]="1"
 off=38 len=14 span[header_field]="Content-Length"
@@ -101,7 +109,9 @@ Transfer-Encoding: identity
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=1 span[header_value]="1"
 off=38 len=17 span[header_field]="Transfer-Encoding"
@@ -122,7 +132,9 @@ Transfer-Encoding: chunked
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=1 span[header_value]="1"
 off=38 len=17 span[header_field]="Transfer-Encoding"
@@ -143,12 +155,14 @@ Transfer-Encoding: identity
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=14 span[header_field]="Content-Length"
 off=35 len=1 span[header_value]="1"
 off=38 len=17 span[header_field]="Transfer-Encoding"
 off=57 len=8 span[header_value]="identity"
-off=69 headers complete method=4 v=1/1 flags=320 content_length=1
+off=69 headers complete v=1/1 flags=320 content_length=1
 ```
 
 ## Funky `Content-Length` with body
@@ -163,10 +177,12 @@ HELLO
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=36 span[url]="/get_funky_content_length_body_hello"
+off=41 len=4 span[protocol]="HTTP"
 off=51 len=14 span[header_field]="conTENT-Length"
 off=67 len=1 span[header_value]="5"
-off=72 headers complete method=1 v=1/0 flags=20 content_length=5
+off=72 headers complete v=1/0 flags=20 content_length=5
 off=72 len=5 span[body]="HELLO"
 off=77 message complete
 ```
@@ -183,10 +199,12 @@ Content-Length:  42
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=14 span[header_field]="Content-Length"
 off=34 len=3 span[header_value]="42 "
-off=41 headers complete method=3 v=1/1 flags=20 content_length=42
+off=41 headers complete v=1/1 flags=20 content_length=42
 ```
 
 ### Spaces in `Content-Length` #2
@@ -201,7 +219,9 @@ Content-Length: 4 2
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=14 span[header_field]="Content-Length"
 off=33 len=2 span[header_value]="4 "
 off=35 error code=11 reason="Invalid character in Content-Length"
@@ -219,7 +239,9 @@ Content-Length: 13 37
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=14 span[header_field]="Content-Length"
 off=33 len=3 span[header_value]="13 "
 off=36 error code=11 reason="Invalid character in Content-Length"
@@ -237,7 +259,9 @@ Content-Length:
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=1 span[url]="/"
+off=7 len=4 span[protocol]="HTTP"
 off=17 len=14 span[header_field]="Content-Length"
 off=34 error code=11 reason="Empty Content-Length"
 ```

--- a/test/request/finish.md
+++ b/test/request/finish.md
@@ -14,8 +14,10 @@ GET / HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
-off=18 headers complete method=1 v=1/1 flags=0 content_length=0
+off=6 len=4 span[protocol]="HTTP"
+off=18 headers complete v=1/1 flags=0 content_length=0
 off=18 message complete
 off=NULL finish=0
 ```
@@ -31,7 +33,9 @@ Content-Length: 100
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=14 span[header_field]="Content-Length"
 off=32 len=3 span[header_value]="100"
 off=NULL finish=2
@@ -47,7 +51,9 @@ Content-Leng
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=12 span[header_field]="Content-Leng"
 off=NULL finish=2
 ```

--- a/test/request/invalid.md
+++ b/test/request/invalid.md
@@ -1,38 +1,6 @@
 Invalid requests
 ================
 
-### ICE protocol and GET method
-
-<!-- meta={"type": "request"} -->
-```http
-GET /music/sweet/music ICE/1.0
-Host: example.com
-
-
-```
-
-```log
-off=0 message begin
-off=4 len=18 span[url]="/music/sweet/music"
-off=27 error code=8 reason="Expected SOURCE method for ICE/x.x request"
-```
-
-### ICE protocol, but not really
-
-<!-- meta={"type": "request"} -->
-```http
-GET /music/sweet/music IHTTP/1.0
-Host: example.com
-
-
-```
-
-```log
-off=0 message begin
-off=4 len=18 span[url]="/music/sweet/music"
-off=24 error code=8 reason="Expected HTTP/"
-```
-
 ### Headers separated by CR
 
 <!-- meta={"type": "request"} -->
@@ -45,7 +13,9 @@ Foo: 1\rBar: 2
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=3 span[header_field]="Foo"
 off=21 len=1 span[header_value]="1"
 off=23 error code=3 reason="Missing expected LF after header value"
@@ -63,7 +33,9 @@ Fo@: Failure
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=18 error code=10 reason="Invalid header token"
 ```
 
@@ -79,22 +51,10 @@ Foo\01\test: Bar
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=19 error code=10 reason="Invalid header token"
-```
-
-### Invalid method
-
-<!-- meta={"type": "request"} -->
-```http
-MKCOLA / HTTP/1.1
-
-
-```
-
-```log
-off=0 message begin
-off=5 error code=6 reason="Expected space after method"
 ```
 
 ### Illegal header field name line folding
@@ -110,7 +70,9 @@ name
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=20 error code=10 reason="Invalid header token"
 ```
 
@@ -128,7 +90,9 @@ Accept-Encoding: gzip
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=4 span[header_field]="Host"
 off=22 len=15 span[header_value]="www.example.com"
 off=49 error code=10 reason="Invalid header token"
@@ -148,7 +112,9 @@ Accept-Encoding: gzip
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=4 span[header_field]="Host"
 off=22 len=15 span[header_value]="www.example.com"
 off=52 error code=10 reason="Invalid header token"

--- a/test/request/lenient.md
+++ b/test/request/lenient.md
@@ -15,10 +15,12 @@ Header1: \f
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=7 span[header_field]="Header1"
 off=28 len=1 span[header_value]="\f"
-off=33 headers complete method=1 v=1/1 flags=100 content_length=0
+off=33 headers complete v=1/1 flags=100 content_length=0
 off=33 message complete
 ```
 
@@ -38,16 +40,20 @@ Header1: \f
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=7 span[header_field]="Header1"
 off=28 len=4 span[header_value]="Okay"
-off=36 headers complete method=1 v=1/1 flags=100 content_length=0
+off=36 headers complete v=1/1 flags=100 content_length=0
 off=36 message complete
 off=38 message begin
+off=38 len=3 span[method]="GET"
 off=42 len=4 span[url]="/url"
+off=47 len=4 span[protocol]="HTTP"
 off=57 len=7 span[header_field]="Header1"
 off=66 len=1 span[header_value]="\f"
-off=71 headers complete method=1 v=1/1 flags=100 content_length=0
+off=71 headers complete v=1/1 flags=100 content_length=0
 off=71 message complete
 ```
 
@@ -64,7 +70,9 @@ Header1: \f
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=7 span[header_field]="Header1"
 off=28 error code=10 reason="Invalid header value char"
 ```

--- a/test/request/method.md
+++ b/test/request/method.md
@@ -12,8 +12,10 @@ REPORT /test HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=6 span[method]="REPORT"
 off=7 len=5 span[url]="/test"
-off=25 headers complete method=20 v=1/1 flags=0 content_length=0
+off=13 len=4 span[protocol]="HTTP"
+off=25 headers complete v=1/1 flags=0 content_length=0
 off=25 message complete
 ```
 
@@ -31,12 +33,14 @@ and yet even more data
 
 ```log
 off=0 message begin
+off=0 len=7 span[method]="CONNECT"
 off=8 len=24 span[url]="0-home0.netscape.com:443"
+off=33 len=4 span[protocol]="HTTP"
 off=43 len=10 span[header_field]="User-agent"
 off=55 len=12 span[header_value]="Mozilla/1.1N"
 off=69 len=19 span[header_field]="Proxy-authorization"
 off=90 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
-off=116 headers complete method=5 v=1/0 flags=0 content_length=0
+off=116 headers complete v=1/0 flags=400 content_length=0
 off=116 message complete
 off=116 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -54,12 +58,14 @@ Proxy-authorization: basic aGVsbG86d29ybGQ=
 
 ```log
 off=0 message begin
+off=0 len=7 span[method]="CONNECT"
 off=8 len=22 span[url]="HOME0.NETSCAPE.COM:443"
+off=31 len=4 span[protocol]="HTTP"
 off=41 len=10 span[header_field]="User-agent"
 off=53 len=12 span[header_value]="Mozilla/1.1N"
 off=67 len=19 span[header_field]="Proxy-authorization"
 off=88 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
-off=114 headers complete method=5 v=1/0 flags=0 content_length=0
+off=114 headers complete v=1/0 flags=400 content_length=0
 off=114 message complete
 off=114 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -78,16 +84,55 @@ blarfcicle"
 
 ```log
 off=0 message begin
+off=0 len=7 span[method]="CONNECT"
 off=8 len=15 span[url]="foo.bar.com:443"
+off=24 len=4 span[protocol]="HTTP"
 off=34 len=10 span[header_field]="User-agent"
 off=46 len=12 span[header_value]="Mozilla/1.1N"
 off=60 len=19 span[header_field]="Proxy-authorization"
 off=81 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
 off=105 len=14 span[header_field]="Content-Length"
 off=121 len=2 span[header_value]="10"
-off=127 headers complete method=5 v=1/0 flags=20 content_length=10
+off=127 headers complete v=1/0 flags=420 content_length=10
 off=127 message complete
 off=127 error code=22 reason="Pause on CONNECT/Upgrade"
+```
+
+### Not a CONNECT request
+
+<!-- meta={"type": "request"} -->
+```http
+CONNECTION 0-home0.netscape.com:443 HTTP/1.0
+User-agent: Mozilla/1.1N
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=10 span[method]="CONNECTION"
+off=11 error code=7 reason="Unexpected start char in url"
+```
+
+### Not a CONNECT request with valid url
+
+<!-- meta={"type": "request"} -->
+```http
+CONNECTION /url HTTP/1.0
+User-agent: Mozilla/1.1N
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=10 span[method]="CONNECTION"
+off=11 len=4 span[url]="/url"
+off=16 len=4 span[protocol]="HTTP"
+off=26 len=10 span[header_field]="User-agent"
+off=38 len=12 span[header_value]="Mozilla/1.1N"
+off=54 headers complete v=1/0 flags=0 content_length=0
+off=54 message complete
 ```
 
 ### M-SEARCH request
@@ -104,14 +149,16 @@ ST: "ssdp:all"
 
 ```log
 off=0 message begin
+off=0 len=8 span[method]="M-SEARCH"
 off=9 len=1 span[url]="*"
+off=11 len=4 span[protocol]="HTTP"
 off=21 len=4 span[header_field]="HOST"
 off=27 len=20 span[header_value]="239.255.255.250:1900"
 off=49 len=3 span[header_field]="MAN"
 off=54 len=15 span[header_value]=""ssdp:discover""
 off=71 len=2 span[header_field]="ST"
 off=75 len=10 span[header_value]=""ssdp:all""
-off=89 headers complete method=24 v=1/1 flags=0 content_length=0
+off=89 headers complete v=1/1 flags=0 content_length=0
 off=89 message complete
 ```
 
@@ -130,7 +177,9 @@ cccccccccc
 
 ```log
 off=0 message begin
+off=0 len=5 span[method]="PATCH"
 off=6 len=9 span[url]="/file.txt"
+off=16 len=4 span[protocol]="HTTP"
 off=26 len=4 span[header_field]="Host"
 off=32 len=15 span[header_value]="www.example.com"
 off=49 len=12 span[header_field]="Content-Type"
@@ -139,7 +188,7 @@ off=84 len=8 span[header_field]="If-Match"
 off=94 len=11 span[header_value]=""e0023aa4e""
 off=107 len=14 span[header_field]="Content-Length"
 off=123 len=2 span[header_value]="10"
-off=129 headers complete method=28 v=1/1 flags=20 content_length=10
+off=129 headers complete v=1/1 flags=20 content_length=10
 off=129 len=10 span[body]="cccccccccc"
 off=139 message complete
 ```
@@ -156,10 +205,12 @@ Host: www.example.com
 
 ```log
 off=0 message begin
+off=0 len=5 span[method]="PURGE"
 off=6 len=9 span[url]="/file.txt"
+off=16 len=4 span[protocol]="HTTP"
 off=26 len=4 span[header_field]="Host"
 off=32 len=15 span[header_value]="www.example.com"
-off=51 headers complete method=29 v=1/1 flags=0 content_length=0
+off=51 headers complete v=1/1 flags=0 content_length=0
 off=51 message complete
 ```
 
@@ -175,10 +226,12 @@ Host: www.example.com
 
 ```log
 off=0 message begin
+off=0 len=6 span[method]="SEARCH"
 off=7 len=1 span[url]="/"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=4 span[header_field]="Host"
 off=25 len=15 span[header_value]="www.example.com"
-off=44 headers complete method=14 v=1/1 flags=0 content_length=0
+off=44 headers complete v=1/1 flags=0 content_length=0
 off=44 message complete
 ```
 
@@ -196,14 +249,16 @@ Link: <http://example.com/profiles/sally>; rel="tag"
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="LINK"
 off=5 len=18 span[url]="/images/my_dog.jpg"
+off=24 len=4 span[protocol]="HTTP"
 off=34 len=4 span[header_field]="Host"
 off=40 len=11 span[header_value]="example.com"
 off=53 len=4 span[header_field]="Link"
 off=59 len=44 span[header_value]="<http://example.com/profiles/joe>; rel="tag""
 off=105 len=4 span[header_field]="Link"
 off=111 len=46 span[header_value]="<http://example.com/profiles/sally>; rel="tag""
-off=161 headers complete method=31 v=1/1 flags=0 content_length=0
+off=161 headers complete v=1/1 flags=0 content_length=0
 off=161 message complete
 ```
 
@@ -220,12 +275,14 @@ Link: <http://example.com/profiles/sally>; rel="tag"
 
 ```log
 off=0 message begin
+off=0 len=6 span[method]="UNLINK"
 off=7 len=18 span[url]="/images/my_dog.jpg"
+off=26 len=4 span[protocol]="HTTP"
 off=36 len=4 span[header_field]="Host"
 off=42 len=11 span[header_value]="example.com"
 off=55 len=4 span[header_field]="Link"
 off=61 len=46 span[header_value]="<http://example.com/profiles/sally>; rel="tag""
-off=111 headers complete method=32 v=1/1 flags=0 content_length=0
+off=111 headers complete v=1/1 flags=0 content_length=0
 off=111 message complete
 ```
 
@@ -241,10 +298,12 @@ Host: example.com
 
 ```log
 off=0 message begin
+off=0 len=6 span[method]="SOURCE"
 off=7 len=18 span[url]="/music/sweet/music"
+off=26 len=4 span[protocol]="HTTP"
 off=36 len=4 span[header_field]="Host"
 off=42 len=11 span[header_value]="example.com"
-off=57 headers complete method=33 v=1/1 flags=0 content_length=0
+off=57 headers complete v=1/1 flags=0 content_length=0
 off=57 message complete
 ```
 
@@ -260,29 +319,29 @@ Host: example.com
 
 ```log
 off=0 message begin
+off=0 len=6 span[method]="SOURCE"
 off=7 len=18 span[url]="/music/sweet/music"
+off=26 len=3 span[protocol]="ICE"
 off=35 len=4 span[header_field]="Host"
 off=41 len=11 span[header_value]="example.com"
-off=56 headers complete method=33 v=1/0 flags=0 content_length=0
+off=56 headers complete v=1/0 flags=0 content_length=0
 off=56 message complete
 ```
 
-### PRI request HTTP2
+### Custom method
 
 <!-- meta={"type": "request"} -->
 ```http
-PRI * HTTP/1.1
-
-SM
+MKCOLA / HTTP/1.1
 
 
 ```
 
 ```log
 off=0 message begin
-off=4 len=1 span[url]="*"
-off=18 headers complete method=34 v=1/1 flags=0 content_length=0
-off=18 message complete
-off=18 message begin
-off=19 error code=6 reason="Invalid method encountered"
+off=0 len=6 span[method]="MKCOLA"
+off=7 len=1 span[url]="/"
+off=9 len=4 span[protocol]="HTTP"
+off=21 headers complete v=1/1 flags=0 content_length=0
+off=21 message complete
 ```

--- a/test/request/sample.md
+++ b/test/request/sample.md
@@ -16,12 +16,14 @@ Header2:\t Value2
 
 ```log
 off=0 message begin
+off=0 len=7 span[method]="OPTIONS"
 off=8 len=4 span[url]="/url"
+off=13 len=4 span[protocol]="HTTP"
 off=23 len=7 span[header_field]="Header1"
 off=32 len=6 span[header_value]="Value1"
 off=40 len=7 span[header_field]="Header2"
 off=50 len=6 span[header_value]="Value2"
-off=60 headers complete method=6 v=1/1 flags=0 content_length=0
+off=60 headers complete v=1/1 flags=0 content_length=0
 off=60 message complete
 ```
 
@@ -41,8 +43,10 @@ HEAD /url HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="HEAD"
 off=5 len=4 span[url]="/url"
-off=22 headers complete method=2 v=1/1 flags=0 content_length=0
+off=10 len=4 span[protocol]="HTTP"
+off=22 headers complete v=1/1 flags=0 content_length=0
 off=22 message complete
 ```
 
@@ -60,14 +64,16 @@ Accept: */*
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=5 span[url]="/test"
+off=10 len=4 span[protocol]="HTTP"
 off=20 len=10 span[header_field]="User-Agent"
 off=32 len=85 span[header_value]="curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1"
 off=119 len=4 span[header_field]="Host"
 off=125 len=12 span[header_value]="0.0.0.0=5000"
 off=139 len=6 span[header_field]="Accept"
 off=147 len=3 span[header_value]="*/*"
-off=154 headers complete method=1 v=1/1 flags=0 content_length=0
+off=154 headers complete v=1/1 flags=0 content_length=0
 off=154 message complete
 ```
 
@@ -90,7 +96,9 @@ Connection: keep-alive
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=12 span[url]="/favicon.ico"
+off=17 len=4 span[protocol]="HTTP"
 off=27 len=4 span[header_field]="Host"
 off=33 len=12 span[header_value]="0.0.0.0=5000"
 off=47 len=10 span[header_field]="User-Agent"
@@ -107,7 +115,7 @@ off=322 len=10 span[header_field]="Keep-Alive"
 off=334 len=3 span[header_value]="300"
 off=339 len=10 span[header_field]="Connection"
 off=351 len=10 span[header_value]="keep-alive"
-off=365 headers complete method=1 v=1/1 flags=1 content_length=0
+off=365 headers complete v=1/1 flags=1 content_length=0
 off=365 message complete
 ```
 
@@ -123,10 +131,12 @@ aaaaaaaaaaaaa:++++++++++
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=9 span[url]="/dumbpack"
+off=14 len=4 span[protocol]="HTTP"
 off=24 len=13 span[header_field]="aaaaaaaaaaaaa"
 off=38 len=10 span[header_value]="++++++++++"
-off=52 headers complete method=1 v=1/1 flags=0 content_length=0
+off=52 headers complete v=1/1 flags=0 content_length=0
 off=52 message complete
 ```
 
@@ -141,8 +151,10 @@ GET /get_no_headers_no_body/world HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=29 span[url]="/get_no_headers_no_body/world"
-off=46 headers complete method=1 v=1/1 flags=0 content_length=0
+off=34 len=4 span[protocol]="HTTP"
+off=46 headers complete v=1/1 flags=0 content_length=0
 off=46 message complete
 ```
 
@@ -158,10 +170,12 @@ Accept: */*
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=23 span[url]="/get_one_header_no_body"
+off=28 len=4 span[protocol]="HTTP"
 off=38 len=6 span[header_field]="Accept"
 off=46 len=3 span[header_value]="*/*"
-off=53 headers complete method=1 v=1/1 flags=0 content_length=0
+off=53 headers complete v=1/1 flags=0 content_length=0
 off=53 message complete
 ```
 
@@ -182,14 +196,16 @@ Accept: */*
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=5 span[url]="/test"
+off=10 len=4 span[protocol]="HTTP"
 off=20 len=4 span[header_field]="Host"
 off=26 len=12 span[header_value]="0.0.0.0:5000"
 off=40 len=10 span[header_field]="User-Agent"
 off=52 len=15 span[header_value]="ApacheBench/2.3"
 off=69 len=6 span[header_field]="Accept"
 off=77 len=3 span[header_value]="*/*"
-off=84 headers complete method=1 v=1/0 flags=0 content_length=0
+off=84 headers complete v=1/0 flags=0 content_length=0
 off=84 message complete
 ```
 
@@ -207,8 +223,10 @@ will send an extra CRLF before the next request.
 
 ```log
 off=2 message begin
+off=2 len=3 span[method]="GET"
 off=6 len=5 span[url]="/test"
-off=24 headers complete method=1 v=1/1 flags=0 content_length=0
+off=12 len=4 span[protocol]="HTTP"
+off=24 headers complete v=1/1 flags=0 content_length=0
 off=24 message complete
 ```
 
@@ -223,8 +241,9 @@ GET /
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
-off=9 headers complete method=1 v=0/9 flags=0 content_length=0
+off=9 headers complete v=0/9 flags=0 content_length=0
 off=9 message complete
 ```
 
@@ -252,7 +271,9 @@ Connection:
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=5 span[header_field]="Line1"
 off=25 len=3 span[header_value]="abc"
 off=30 len=4 span[header_value]="\tdef"
@@ -268,7 +289,7 @@ off=98 len=5 span[header_field]="Line4"
 off=110 len=0 span[header_value]=""
 off=110 len=10 span[header_field]="Connection"
 off=124 len=5 span[header_value]="close"
-off=133 headers complete method=1 v=1/1 flags=2 content_length=0
+off=133 headers complete v=1/1 flags=2 content_length=0
 off=133 message complete
 ```
 
@@ -295,7 +316,9 @@ Connection:\n\
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=15 len=5 span[header_field]="Line1"
 off=24 len=3 span[header_value]="abc"
 off=28 len=4 span[header_value]="\tdef"
@@ -311,7 +334,7 @@ off=88 len=5 span[header_field]="Line4"
 off=98 len=0 span[header_value]=""
 off=98 len=10 span[header_field]="Connection"
 off=111 len=5 span[header_value]="close"
-off=118 headers complete method=1 v=1/1 flags=2 content_length=0
+off=118 headers complete v=1/1 flags=2 content_length=0
 off=118 message complete
 ```
 
@@ -327,10 +350,12 @@ Header1: Value1
 
 ```log
 off=2 message begin
+off=2 len=3 span[method]="GET"
 off=6 len=4 span[url]="/url"
+off=11 len=4 span[protocol]="HTTP"
 off=21 len=7 span[header_field]="Header1"
 off=30 len=6 span[header_value]="Value1"
-off=40 headers complete method=1 v=1/1 flags=0 content_length=0
+off=40 headers complete v=1/1 flags=0 content_length=0
 off=40 message complete
 ```
 
@@ -348,11 +373,61 @@ Test: Düsseldorf
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=4 span[header_field]="Test"
 off=22 len=11 span[header_value]="Düsseldorf"
-off=37 headers complete method=1 v=1/1 flags=0 content_length=0
+off=37 headers complete v=1/1 flags=0 content_length=0
 off=37 message complete
+```
+
+### Custom protocol
+
+<!-- meta={"type": "request"} -->
+```http
+GET /music/sweet/music IHTTP/1.0
+Host: example.com
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=3 span[method]="GET"
+off=4 len=18 span[url]="/music/sweet/music"
+off=23 len=5 span[protocol]="IHTTP"
+off=34 len=4 span[header_field]="Host"
+off=40 len=11 span[header_value]="example.com"
+off=55 headers complete v=1/0 flags=0 content_length=0
+off=55 message complete
+```
+
+## RTSP protocol
+
+<!-- meta={"type": "request"} -->
+```http
+OPTIONS rtsp://example.com/media.mp4 RTSP/1.0
+CSeq: 1
+Require: implicit-play
+Proxy-Require: gzipped-messages
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=7 span[method]="OPTIONS"
+off=8 len=28 span[url]="rtsp://example.com/media.mp4"
+off=37 len=4 span[protocol]="RTSP"
+off=47 len=4 span[header_field]="CSeq"
+off=53 len=1 span[header_value]="1"
+off=56 len=7 span[header_field]="Require"
+off=65 len=13 span[header_value]="implicit-play"
+off=80 len=13 span[header_field]="Proxy-Require"
+off=95 len=16 span[header_value]="gzipped-messages"
+off=115 headers complete v=1/0 flags=0 content_length=0
+off=115 message complete
 ```
 
 ## X-SSL-Nonsense
@@ -400,7 +475,9 @@ X-SSL-Nonsense:   -----BEGIN CERTIFICATE-----
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=1 span[url]="/"
+off=6 len=4 span[protocol]="HTTP"
 off=16 len=14 span[header_field]="X-SSL-Nonsense"
 off=34 len=27 span[header_value]="-----BEGIN CERTIFICATE-----"
 off=63 len=65 span[header_value]="\tMIIFbTCCBFWgAwIBAgICH4cwDQYJKoZIhvcNAQEFBQAwcDELMAkGA1UEBhMCVUsx"
@@ -434,7 +511,7 @@ off=1873 len=65 span[header_value]="\twTC6o2xq5y0qZ03JonF7OJspEd3I5zKY3E+ov7/ZhW
 off=1940 len=65 span[header_value]="\tYhixw1aKEPzNjNowuIseVogKOLXxWI5vAi5HgXdS0/ES5gDGsABo4fqovUKlgop3"
 off=2007 len=5 span[header_value]="\tRA=="
 off=2014 len=26 span[header_value]="\t-----END CERTIFICATE-----"
-off=2044 headers complete method=1 v=1/1 flags=0 content_length=0
+off=2044 headers complete v=1/1 flags=0 content_length=0
 off=2044 message complete
 ```
 

--- a/test/request/transfer-encoding.md
+++ b/test/request/transfer-encoding.md
@@ -15,10 +15,12 @@ Transfer-Encoding: chunked
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=17 span[header_field]="Transfer-Encoding"
 off=38 len=7 span[header_value]="chunked"
-off=49 headers complete method=4 v=1/1 flags=208 content_length=0
+off=49 headers complete v=1/1 flags=208 content_length=0
 ```
 
 ### Parse chunks with lowercase size
@@ -37,10 +39,12 @@ a
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=17 span[header_field]="Transfer-Encoding"
 off=38 len=7 span[header_value]="chunked"
-off=49 headers complete method=4 v=1/1 flags=208 content_length=0
+off=49 headers complete v=1/1 flags=208 content_length=0
 off=52 chunk header len=10
 off=52 len=10 span[body]="0123456789"
 off=64 chunk complete
@@ -65,10 +69,12 @@ A
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=17 span[header_field]="Transfer-Encoding"
 off=38 len=7 span[header_value]="chunked"
-off=49 headers complete method=4 v=1/1 flags=208 content_length=0
+off=49 headers complete v=1/1 flags=208 content_length=0
 off=52 chunk header len=10
 off=52 len=10 span[body]="0123456789"
 off=64 chunk complete
@@ -93,10 +99,12 @@ all your base are belong to us
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=27 span[url]="/post_chunked_all_your_base"
+off=33 len=4 span[protocol]="HTTP"
 off=43 len=17 span[header_field]="Transfer-Encoding"
 off=62 len=7 span[header_value]="chunked"
-off=73 headers complete method=3 v=1/1 flags=208 content_length=0
+off=73 headers complete v=1/1 flags=208 content_length=0
 off=77 chunk header len=30
 off=77 len=30 span[body]="all your base are belong to us"
 off=109 chunk complete
@@ -123,10 +131,12 @@ hello
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=25 span[url]="/two_chunks_mult_zero_end"
+off=31 len=4 span[protocol]="HTTP"
 off=41 len=17 span[header_field]="Transfer-Encoding"
 off=60 len=7 span[header_value]="chunked"
-off=71 headers complete method=3 v=1/1 flags=208 content_length=0
+off=71 headers complete v=1/1 flags=208 content_length=0
 off=74 chunk header len=5
 off=74 len=5 span[body]="hello"
 off=81 chunk complete
@@ -158,10 +168,12 @@ Content-Type: text/plain
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=27 span[url]="/chunked_w_trailing_headers"
+off=33 len=4 span[protocol]="HTTP"
 off=43 len=17 span[header_field]="Transfer-Encoding"
 off=62 len=7 span[header_value]="chunked"
-off=73 headers complete method=3 v=1/1 flags=208 content_length=0
+off=73 headers complete v=1/1 flags=208 content_length=0
 off=76 chunk header len=5
 off=76 len=5 span[body]="hello"
 off=83 chunk complete
@@ -194,10 +206,12 @@ hello
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=32 span[url]="/chunked_w_unicorns_after_length"
+off=38 len=4 span[protocol]="HTTP"
 off=48 len=17 span[header_field]="Transfer-Encoding"
 off=67 len=7 span[header_value]="chunked"
-off=78 headers complete method=3 v=1/1 flags=208 content_length=0
+off=78 headers complete v=1/1 flags=208 content_length=0
 off=123 chunk header len=5
 off=123 len=5 span[body]="hello"
 off=130 chunk complete
@@ -222,10 +236,12 @@ Transfer-Encoding: pigeons
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=17 span[header_field]="Transfer-Encoding"
 off=38 len=7 span[header_value]="pigeons"
-off=49 headers complete method=4 v=1/1 flags=200 content_length=0
+off=49 headers complete v=1/1 flags=200 content_length=0
 off=49 error code=15 reason="Request has invalid `Transfer-Encoding`"
 ```
 
@@ -243,7 +259,9 @@ World
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 len=4 span[protocol]="HTTP"
 off=54 len=6 span[header_field]="Accept"
 off=62 len=3 span[header_value]="*/*"
 off=67 len=17 span[header_field]="Transfer-Encoding"
@@ -273,14 +291,16 @@ World
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 len=4 span[protocol]="HTTP"
 off=54 len=6 span[header_field]="Accept"
 off=62 len=3 span[header_value]="*/*"
 off=67 len=17 span[header_field]="Transfer-Encoding"
 off=86 len=8 span[header_value]="identity"
 off=96 len=14 span[header_field]="Content-Length"
 off=112 len=1 span[header_value]="1"
-off=117 headers complete method=3 v=1/1 flags=320 content_length=1
+off=117 headers complete v=1/1 flags=320 content_length=1
 off=117 len=5 span[body]="World"
 ```
 
@@ -297,12 +317,14 @@ World
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 len=4 span[protocol]="HTTP"
 off=54 len=6 span[header_field]="Accept"
 off=62 len=3 span[header_value]="*/*"
 off=67 len=17 span[header_field]="Transfer-Encoding"
 off=86 len=16 span[header_value]="chunked, deflate"
-off=106 headers complete method=3 v=1/1 flags=200 content_length=0
+off=106 headers complete v=1/1 flags=200 content_length=0
 off=106 error code=15 reason="Request has invalid `Transfer-Encoding`"
 ```
 
@@ -322,12 +344,14 @@ World
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 len=4 span[protocol]="HTTP"
 off=54 len=6 span[header_field]="Accept"
 off=62 len=3 span[header_value]="*/*"
 off=67 len=17 span[header_field]="Transfer-Encoding"
 off=86 len=16 span[header_value]="chunked, deflate"
-off=106 headers complete method=3 v=1/1 flags=300 content_length=0
+off=106 headers complete v=1/1 flags=300 content_length=0
 off=106 len=5 span[body]="World"
 ```
 
@@ -348,12 +372,14 @@ World
 
 ```log
 off=0 message begin
+off=0 len=4 span[method]="POST"
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 len=4 span[protocol]="HTTP"
 off=54 len=6 span[header_field]="Accept"
 off=62 len=3 span[header_value]="*/*"
 off=67 len=17 span[header_field]="Transfer-Encoding"
 off=86 len=16 span[header_value]="deflate, chunked"
-off=106 headers complete method=3 v=1/1 flags=208 content_length=0
+off=106 headers complete v=1/1 flags=208 content_length=0
 off=109 chunk header len=5
 off=109 len=5 span[body]="World"
 off=116 chunk complete
@@ -377,10 +403,12 @@ foo
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="PUT"
 off=4 len=4 span[url]="/url"
+off=9 len=4 span[protocol]="HTTP"
 off=19 len=17 span[header_field]="Transfer-Encoding"
 off=38 len=7 span[header_value]="chunked"
-off=49 headers complete method=4 v=1/1 flags=208 content_length=0
+off=49 headers complete v=1/1 flags=208 content_length=0
 off=52 chunk header len=3
 off=52 len=3 span[body]="foo"
 off=57 chunk complete

--- a/test/request/uri.md
+++ b/test/request/uri.md
@@ -12,8 +12,10 @@ GET /with_"lovely"_quotes?foo=\"bar\" HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=33 span[url]="/with_"lovely"_quotes?foo=\"bar\""
-off=50 headers complete method=1 v=1/1 flags=0 content_length=0
+off=38 len=4 span[protocol]="HTTP"
+off=50 headers complete v=1/1 flags=0 content_length=0
 off=50 message complete
 ```
 
@@ -30,8 +32,10 @@ GET /test.cgi?foo=bar?baz HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=21 span[url]="/test.cgi?foo=bar?baz"
-off=38 headers complete method=1 v=1/1 flags=0 content_length=0
+off=26 len=4 span[protocol]="HTTP"
+off=38 headers complete v=1/1 flags=0 content_length=0
 off=38 message complete
 ```
 
@@ -46,8 +50,10 @@ GET http://hypnotoad.org?hail=all HTTP/1.1\r\n
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=29 span[url]="http://hypnotoad.org?hail=all"
-off=46 headers complete method=1 v=1/1 flags=0 content_length=0
+off=34 len=4 span[protocol]="HTTP"
+off=46 headers complete v=1/1 flags=0 content_length=0
 off=46 message complete
 ```
 
@@ -62,8 +68,10 @@ GET http://hypnotoad.org:1234?hail=all HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=34 span[url]="http://hypnotoad.org:1234?hail=all"
-off=51 headers complete method=1 v=1/1 flags=0 content_length=0
+off=39 len=4 span[protocol]="HTTP"
+off=51 headers complete v=1/1 flags=0 content_length=0
 off=51 message complete
 ```
 
@@ -82,8 +90,10 @@ GET /test.cgi?query=| HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=17 span[url]="/test.cgi?query=|"
-off=34 headers complete method=1 v=1/1 flags=0 content_length=0
+off=22 len=4 span[protocol]="HTTP"
+off=34 headers complete v=1/1 flags=0 content_length=0
 off=34 message complete
 ```
 
@@ -98,8 +108,10 @@ GET http://hypnotoad.org:1234 HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=25 span[url]="http://hypnotoad.org:1234"
-off=42 headers complete method=1 v=1/1 flags=0 content_length=0
+off=30 len=4 span[protocol]="HTTP"
+off=42 headers complete v=1/1 flags=0 content_length=0
 off=42 message complete
 ```
 
@@ -115,10 +127,12 @@ Host: github.com
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=36 span[url]="/δ¶/δt/космос/pope?q=1#narf"
+off=41 len=4 span[protocol]="HTTP"
 off=51 len=4 span[header_field]="Host"
 off=57 len=10 span[header_value]="github.com"
-off=71 headers complete method=1 v=1/1 flags=0 content_length=0
+off=71 headers complete v=1/1 flags=0 content_length=0
 off=71 message complete
 ```
 
@@ -134,6 +148,7 @@ Host: github.com
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=5 error code=7 reason="Invalid char in url path"
 ```
 
@@ -148,8 +163,10 @@ GET /forums/1/topics/2375?page=1#posts-17408 HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=40 span[url]="/forums/1/topics/2375?page=1#posts-17408"
-off=57 headers complete method=1 v=1/1 flags=0 content_length=0
+off=45 len=4 span[protocol]="HTTP"
+off=57 headers complete v=1/1 flags=0 content_length=0
 off=57 message complete
 ```
 
@@ -166,12 +183,14 @@ Proxy-authorization: basic aGVsbG86d29ybGQ=
 
 ```log
 off=0 message begin
+off=0 len=7 span[method]="CONNECT"
 off=8 len=23 span[url]="home_0.netscape.com:443"
+off=32 len=4 span[protocol]="HTTP"
 off=42 len=10 span[header_field]="User-agent"
 off=54 len=12 span[header_value]="Mozilla/1.1N"
 off=68 len=19 span[header_field]="Proxy-authorization"
 off=89 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
-off=115 headers complete method=5 v=1/0 flags=0 content_length=0
+off=115 headers complete v=1/0 flags=400 content_length=0
 off=115 message complete
 off=115 error code=22 reason="Pause on CONNECT/Upgrade"
 ```
@@ -187,8 +206,10 @@ GET http://a%12:b!&*$@hypnotoad.org:1234/toto HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=41 span[url]="http://a%12:b!&*$@hypnotoad.org:1234/toto"
-off=58 headers complete method=1 v=1/1 flags=0 content_length=0
+off=46 len=4 span[protocol]="HTTP"
+off=58 headers complete v=1/1 flags=0 content_length=0
 off=58 message complete
 ```
 
@@ -203,6 +224,8 @@ GET /foo bar/ HTTP/1.1
 
 ```log
 off=0 message begin
+off=0 len=3 span[method]="GET"
 off=4 len=4 span[url]="/foo"
-off=9 error code=8 reason="Expected HTTP/"
+off=9 len=3 span[protocol]="bar"
+off=13 error code=9 reason="Invalid major version"
 ```

--- a/test/response/connection.md
+++ b/test/response/connection.md
@@ -16,6 +16,7 @@ hello world
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=12 span[header_field]="Content-Type"
 off=31 len=24 span[header_value]="text/html; charset=UTF-8"
@@ -45,6 +46,7 @@ HTTP/1.0 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=10 span[header_field]="Connection"
 off=29 len=10 span[header_value]="keep-alive"
@@ -66,12 +68,14 @@ HTTP/1.0 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=10 span[status]="No content"
 off=25 len=10 span[header_field]="Connection"
 off=37 len=10 span[header_value]="keep-alive"
 off=51 headers complete status=204 v=1/0 flags=1 content_length=0
 off=51 message complete
 off=51 message begin
+off=51 len=4 span[protocol]="HTTP"
 off=64 len=2 span[status]="OK"
 ```
 
@@ -89,6 +93,7 @@ HTTP/1.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=19 headers complete status=200 v=1/1 flags=0 content_length=0
 off=19 len=15 span[body]="HTTP/1.1 200 OK"
@@ -107,10 +112,12 @@ HTTP/1.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=10 span[status]="No content"
 off=27 headers complete status=204 v=1/1 flags=0 content_length=0
 off=27 message complete
 off=27 message begin
+off=27 len=4 span[protocol]="HTTP"
 off=40 len=2 span[status]="OK"
 ```
 
@@ -126,6 +133,7 @@ HTTP/1.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=10 span[status]="No content"
 off=25 len=10 span[header_field]="Connection"
 off=37 len=5 span[header_value]="close"
@@ -146,12 +154,14 @@ HTTP/1.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=10 span[status]="No content"
 off=25 len=10 span[header_field]="Connection"
 off=37 len=5 span[header_value]="close"
 off=46 headers complete status=204 v=1/1 flags=2 content_length=0
 off=46 message complete
 off=46 message begin
+off=46 len=4 span[protocol]="HTTP"
 off=59 len=2 span[status]="OK"
 ```
 
@@ -170,6 +180,7 @@ proto
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=19 span[status]="Switching Protocols"
 off=34 len=10 span[header_field]="Connection"
 off=46 len=7 span[header_value]="upgrade"
@@ -203,6 +214,7 @@ proto
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=19 span[status]="Switching Protocols"
 off=34 len=10 span[header_field]="Connection"
 off=46 len=7 span[header_value]="upgrade"
@@ -236,6 +248,7 @@ body
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=10 span[header_field]="Connection"
 off=29 len=7 span[header_value]="upgrade"
@@ -259,6 +272,7 @@ body
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=10 span[header_field]="Connection"
 off=29 len=7 span[header_value]="upgrade"
@@ -291,6 +305,7 @@ dy
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=10 span[header_field]="Connection"
 off=29 len=7 span[header_value]="upgrade"

--- a/test/response/content-length.md
+++ b/test/response/content-length.md
@@ -31,6 +31,7 @@ Connection: close
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=4 span[header_field]="Date"
 off=23 len=29 span[header_value]="Tue, 04 Aug 2009 07:59:32 GMT"
@@ -82,6 +83,7 @@ OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=16 span[header_field]="Content-Length-X"
 off=35 len=1 span[header_value]="0"

--- a/test/response/finish.md
+++ b/test/response/finish.md
@@ -14,6 +14,7 @@ HTTP/1.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=19 headers complete status=200 v=1/1 flags=0 content_length=0
 off=NULL finish=1

--- a/test/response/invalid.md
+++ b/test/response/invalid.md
@@ -1,22 +1,6 @@
 Invalid responses
 =================
 
-### Incomplete HTTP protocol
-
-*TODO(indutny): test `req_or_res` mode too*
-
-<!-- meta={"type": "response-only"} -->
-```http
-HTP/1.1 200 OK
-
-
-```
-
-```log
-off=0 message begin
-off=2 error code=8 reason="Expected HTTP/"
-```
-
 ### Extra digit in HTTP major version
 
 <!-- meta={"type": "response"} -->
@@ -28,6 +12,7 @@ HTTP/01.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=6 error code=9 reason="Expected dot"
 ```
 
@@ -42,6 +27,7 @@ HTTP/11.1 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=6 error code=9 reason="Expected dot"
 ```
 
@@ -56,6 +42,7 @@ HTTP/1.01 200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=8 error code=9 reason="Expected space after version"
 ```
 
@@ -70,6 +57,7 @@ HTTP/1.1\t200 OK
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=8 error code=9 reason="Expected space after version"
 ```
 
@@ -84,6 +72,7 @@ off=8 error code=9 reason="Expected space after version"
 
 ```log
 off=1 message begin
+off=1 len=4 span[protocol]="HTTP"
 off=9 error code=9 reason="Expected space after version"
 ```
 
@@ -99,6 +88,7 @@ Foo: 1\rBar: 2
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=3 span[header_field]="Foo"
 off=22 len=1 span[header_value]="1"

--- a/test/response/transfer-encoding.md
+++ b/test/response/transfer-encoding.md
@@ -22,6 +22,7 @@ and this is the second one
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=12 span[header_field]="Content-Type"
 off=31 len=10 span[header_value]="text/plain"
@@ -56,6 +57,7 @@ World
 
 ```log
 off=0 message begin
+off=0 len=4 span[protocol]="HTTP"
 off=13 len=2 span[status]="OK"
 off=17 len=6 span[header_field]="Accept"
 off=25 len=3 span[header_value]="*/*"


### PR DESCRIPTION
I've tried to solve #11 

This introduced `protocol` and `method` additional spans and removed the static methods map.
The removal of the static method map implied a BC break as the http method is now a string and should be retrieved by the embedder registering an `on_method` callback.

It's pretty dirty in the `req_or_res` part, where it is trying to guess if the message is a request or a response. IMHO this behavior should be removed completly and the embedder must pass the message type to the parser: I don't really see a real usage application to keep the things mixed up like this.

Hope this could help