### PR TITLE
release: switch between modes using define

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,6 @@ build/libllhttp.a: build/c/llhttp.o build/native/api.o \
 		build/native/http.o
 	$(AR) rcs $@ build/c/llhttp.o build/native/api.o build/native/http.o
 
-build/bitcode/llhttp.o: build/bitcode/llhttp.bc
-	$(CLANG) $(CFLAGS) -c $< -o $@
-
 build/c/llhttp.o: build/c/llhttp.c
 	$(CLANG) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
@@ -30,7 +27,6 @@ build/native/%.o: src/native/%.c build/llhttp.h src/native/api.h \
 	$(CLANG) $(CFLAGS) $(INCLUDES) -c $< -o $@
 
 build/llhttp.h: generate
-build/bitcode/llhttp.bc: generate
 build/c/llhttp.c: generate
 
 build/native:

--- a/bin/generate.ts
+++ b/bin/generate.ts
@@ -47,13 +47,11 @@ function guard(strict: string, loose: string): string {
 
   out += '#ifdef LLHTTP_STRICT_MODE\n';
   out += '\n';
-  out += strict;
-  out += '\n';
+  out += strict + '\n';
   out += '\n';
   out += '#else  /* !LLHTTP_STRICT_MODE */\n';
   out += '\n';
-  out += loose;
-  out += '\n';
+  out += loose + '\n';
   out += '\n';
   out += '#endif  /* LLHTTP_STRICT_MODE */\n';
 

--- a/bin/generate.ts
+++ b/bin/generate.ts
@@ -32,8 +32,8 @@ function build(mode: 'strict' | 'loose') {
     c: {
       header: 'llhttp',
     },
-    generateBitcode: false,
     debug: process.env.LLPARSE_DEBUG ? 'llhttp__debug' : undefined,
+    generateBitcode: false,
     headerGuard: 'INCLUDE_LLHTTP_ITSELF_H_',
   });
 }
@@ -60,8 +60,10 @@ function guard(strict: string, loose: string): string {
   return out;
 }
 
-const strict = build('strict');
-const loose = build('loose');
+const artifacts = {
+  loose: build('loose'),
+  strict: build('strict'),
+};
 
 let headers = '';
 
@@ -84,7 +86,7 @@ headers += '\n';
 
 const cHeaders = new llhttp.CHeaders();
 
-headers += guard(strict.header, loose.header);
+headers += guard(artifacts.strict.header, artifacts.loose.header);
 
 headers += '\n';
 
@@ -97,5 +99,6 @@ headers += fs.readFileSync(path.join(SRC_DIR, 'native', 'api.h'));
 headers += '\n';
 headers += '#endif  /* INCLUDE_LLHTTP_H_ */\n';
 
-fs.writeFileSync(C_FILE, guard(strict.c || '', loose.c || ''));
+fs.writeFileSync(C_FILE,
+  guard(artifacts.strict.c || '', artifacts.loose.c || ''));
 fs.writeFileSync(HEADER_FILE, headers);

--- a/bin/generate.ts
+++ b/bin/generate.ts
@@ -10,15 +10,13 @@ const pkgFile = path.join(__dirname, '..', 'package.json');
 const pkg = JSON.parse(fs.readFileSync(pkgFile).toString());
 
 const BUILD_DIR = path.join(__dirname, '..', 'build');
-const BITCODE_DIR = path.join(BUILD_DIR, 'bitcode');
 const C_DIR = path.join(BUILD_DIR, 'c');
 const SRC_DIR = path.join(__dirname, '..', 'src');
 
-const BITCODE_FILE = path.join(BITCODE_DIR, 'llhttp.bc');
 const C_FILE = path.join(C_DIR, 'llhttp.c');
 const HEADER_FILE = path.join(BUILD_DIR, 'llhttp.h');
 
-for (const dir of [ BUILD_DIR, BITCODE_DIR, C_DIR ]) {
+for (const dir of [ BUILD_DIR, C_DIR ]) {
   try {
     fs.mkdirSync(dir);
   } catch (e) {
@@ -26,18 +24,44 @@ for (const dir of [ BUILD_DIR, BITCODE_DIR, C_DIR ]) {
   }
 }
 
-const mode = process.argv[2] === 'strict' ? 'strict' : 'loose';
+function build(mode: 'strict' | 'loose') {
+  const llparse = new LLParse('llhttp__internal');
+  const instance = new llhttp.HTTP(llparse, mode);
 
-const llparse = new LLParse('llhttp__internal');
-const instance = new llhttp.HTTP(llparse, mode);
+  return llparse.build(instance.build().entry, {
+    c: {
+      header: 'llhttp',
+    },
+    generateBitcode: false,
+    debug: process.env.LLPARSE_DEBUG ? 'llhttp__debug' : undefined,
+    headerGuard: 'INCLUDE_LLHTTP_ITSELF_H_',
+  });
+}
 
-const artifacts = llparse.build(instance.build().entry, {
-  c: {
-    header: 'llhttp',
-  },
-  debug: process.env.LLPARSE_DEBUG ? 'llhttp__debug' : undefined,
-  headerGuard: 'INCLUDE_LLHTTP_ITSELF_H_',
-});
+function guard(strict: string, loose: string): string {
+  let out = '';
+
+  if (strict === loose) {
+    return strict;
+  }
+
+  out += '#ifdef LLHTTP_STRICT_MODE\n';
+  out += '\n';
+  out += strict;
+  out += '\n';
+  out += '\n';
+  out += '#else  /* !LLHTTP_STRICT_MODE */\n';
+  out += '\n';
+  out += loose;
+  out += '\n';
+  out += '\n';
+  out += '#endif  /* LLHTTP_STRICT_MODE */\n';
+
+  return out;
+}
+
+const strict = build('strict');
+const loose = build('loose');
 
 let headers = '';
 
@@ -53,9 +77,14 @@ headers += `#define LLHTTP_VERSION_MINOR ${version.minor}\n`;
 headers += `#define LLHTTP_VERSION_PATCH ${version.patch}\n`;
 headers += '\n';
 
+headers += '#ifndef LLHTTP_STRICT_MODE\n';
+headers += '# define LLHTTP_STRICT_MODE 1\n';
+headers += '#endif\n';
+headers += '\n';
+
 const cHeaders = new llhttp.CHeaders();
 
-headers += artifacts.header;
+headers += guard(strict.header, loose.header);
 
 headers += '\n';
 
@@ -68,6 +97,5 @@ headers += fs.readFileSync(path.join(SRC_DIR, 'native', 'api.h'));
 headers += '\n';
 headers += '#endif  /* INCLUDE_LLHTTP_H_ */\n';
 
-fs.writeFileSync(BITCODE_FILE, artifacts.bitcode);
-fs.writeFileSync(C_FILE, artifacts.c);
+fs.writeFileSync(C_FILE, guard(strict.c || '', loose.c || ''));
 fs.writeFileSync(HEADER_FILE, headers);


### PR DESCRIPTION
Use `LLHTTP_STRICT_MODE` C define to switch between modes instead of
separate compilation targets.

Remove `bitcode` output as it is slower than C version anyway.

See: https://github.com/envoyproxy/envoy/issues/5155#issuecomment-623424376