### PR TITLE
http: accept 0xFF as a valid character in header values

### DIFF
--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -193,7 +193,7 @@ export const TOKEN: CharList = STRICT_TOKEN.concat([ ' ' ]);
  * character or %x80-FF
  */
 export const HEADER_CHARS: CharList = [ '\t' ];
-for (let i = 32; i < 255; i++) {
+for (let i = 32; i <= 255; i++) {
   if (i !== 127) {
     HEADER_CHARS.push(i);
   }


### PR DESCRIPTION
Hello! I took a stab at trying to fix the issues I'm seeing in https://github.com/nodejs/node/issues/27711#issuecomment-679469574 

I wasn't able to generate a test case using the test suite of this project based on `.md` files, as I couldn't recreate the `0xFF` iso-8859-1 character. However I downloaded the Node source code and copied over the generated C files of this project and then compiled Node itself. When I ran the short program described in the comment above it worked successfully.

I'd like to hear thoughts and opinions on this change.

Kind regards.