### PR TITLE
constants: add RTSP/RAOP methods

### DIFF
--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -98,6 +98,19 @@ export enum METHODS {
   SOURCE = 33,
   /* RFC-7540, section 11.6 */
   PRI = 34,
+  /* RFC-2326 RTSP */
+  DESCRIBE = 35,
+  ANNOUNCE = 36,
+  SETUP = 37,
+  PLAY = 38,
+  PAUSE = 39,
+  TEARDOWN = 40,
+  GET_PARAMETER = 41,
+  SET_PARAMETER = 42,
+  REDIRECT = 43,
+  RECORD = 44,
+  /* RAOP */
+  FLUSH = 45,
 }
 
 export const METHOD_MAP = enumToMap(METHODS);

--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -317,6 +317,7 @@ export class HTTP {
 
     n('req_http_start')
       .match('HTTP/', n('req_http_major'))
+      .match('RTSP/', n('req_http_major'))
       .match('ICE/', isSource)
       .match(' ', n('req_http_start'))
       .otherwise(p.error(ERROR.INVALID_CONSTANT, 'Expected HTTP/'));


### PR DESCRIPTION
I'm looking at replacing http-parser with llhttp in rpiplay [1].  These are
the additional methods used to implement Airplay2 [2].  RTSP [3] uses the
verb OPTIONS and adds DESCRIBE, ANNOUNCE, SETUP, PLAY, PAUSE, TEARDOWN,
GET_PARAMETER, SET_PARAMETER, REDIRECT, & RECORD.  RAOP additionally adds
FLUSH.

[1] https://github.com/FD-/RPiPlay
[2] https://git.zx2c4.com/Airtunes2/about/
[3] https://tools.ietf.org/html/rfc2326

Signed-off-by: Derrick Lyndon Pallas <derrick@pallas.us>