### PR TITLE
http: add additional completion callbacks

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -153,9 +153,23 @@ int llhttp__on_url(llhttp_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_url_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_url_complete, s);
+  return err;
+}
+
+
 int llhttp__on_status(llhttp_t* s, const char* p, const char* endp) {
   int err;
   CALLBACK_MAYBE(s, on_status, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_status_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_status_complete, s);
   return err;
 }
 
@@ -167,9 +181,23 @@ int llhttp__on_header_field(llhttp_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_header_field_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_header_field_complete, s);
+  return err;
+}
+
+
 int llhttp__on_header_value(llhttp_t* s, const char* p, const char* endp) {
   int err;
   CALLBACK_MAYBE(s, on_header_value, s, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_header_value_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_header_value_complete, s);
   return err;
 }
 

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -42,6 +42,11 @@ struct llhttp_settings_s {
    */
   llhttp_cb      on_chunk_header;
   llhttp_cb      on_chunk_complete;
+
+  llhttp_cb      on_url_complete;
+  llhttp_cb      on_status_complete;
+  llhttp_cb      on_header_field_complete;
+  llhttp_cb      on_header_value_complete;
 };
 
 /* Initialize the parser with specific type and user settings.

--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -10,6 +10,14 @@ int llhttp__on_url(llparse_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_url_complete(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+  // llparse__print(p, endp, "url complete");
+  return 0;
+}
+
+
 int llhttp__on_url_schema(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
@@ -75,6 +83,14 @@ int llhttp__on_status(llparse_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_status_complete(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+  // llparse__print(p, endp, "status complete");
+  return 0;
+}
+
+
 int llhttp__on_header_field(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
@@ -82,10 +98,26 @@ int llhttp__on_header_field(llparse_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_header_field_complete(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+  // llparse__print(p, endp, "header_field complete");
+  return 0;
+}
+
+
 int llhttp__on_header_value(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
   return llparse__print_span("header_value", p, endp);
+}
+
+
+int llhttp__on_header_value_complete(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+  // llparse__print(p, endp, "header_value complete");
+  return 0;
 }
 
 


### PR DESCRIPTION
Add completion callbacks for url, status, header_field, & header_value.  If
the parser receives a chunk in the middle of one of these, then we will see
the on_* callback multiple times.  Currently, we must either pass partial
values to another parser OR aggregate values and on transition do something.
The latter leads to code that looks for the transition from the old state in
the new state.

Instead, let llhttp indicate when the transition happens and put the
completion code there.  To that end, this commit adds

	on_url_complete
	on_status_complete
	on_header_field_complete
	on_header_value_complete

The URL completion actually happens after the Protocol/Major/Minor are
determined, but this seems reasonable.  The ensures that the Protocol+Verb
is valid and allows header callbacks to ignore fields based on the
Protocol+Version+Verb+URL.

Benchmark results indicate no change in performance.

Re: tests, stubs were added for the completion events but it was not clear
to me how to update several hundred markdown tests without doing it by hand.
If there is a simple way to add these events to existing md tests, please
let me know.

Validated via upstream changes to https://pypi.org/project/llhttp/

Signed-off-by: Derrick Lyndon Pallas <derrick@pallas.us>