### PR TITLE
http: recognize HTTP2/PRI upgrade

### DIFF
--- a/test/request/method.md
+++ b/test/request/method.md
@@ -321,8 +321,5 @@ SM
 ```log
 off=0 message begin
 off=4 len=1 span[url]="*"
-off=18 headers complete method=34 v=1/1 flags=0 content_length=0
-off=18 message complete
-off=18 message begin
-off=19 error code=6 reason="Invalid method encountered"
+off=24 error code=22 reason="Pause on PRI/Upgrade"
 ```


### PR DESCRIPTION
RFC7540 describes the false PRI method, part of the HTTP/2 Connection
Preface.  It mimics a regular HTTP/1 request, but in reality is an upgrade
request with the bytes

	PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n

When we see this method, we should hand-off as we do any other upgrade.