### PR TITLE
http: fix header completion callbacks for special fields & empty values

### DIFF
--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -13,7 +13,7 @@ int llhttp__on_url(llparse_t* s, const char* p, const char* endp) {
 int llhttp__on_url_complete(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
-  // llparse__print(p, endp, "url complete");
+  llparse__print(p, endp, "url complete");
   return 0;
 }
 
@@ -91,7 +91,7 @@ int llhttp__on_status(llparse_t* s, const char* p, const char* endp) {
 int llhttp__on_status_complete(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
-  // llparse__print(p, endp, "status complete");
+  llparse__print(p, endp, "status complete");
   return 0;
 }
 
@@ -106,7 +106,7 @@ int llhttp__on_header_field(llparse_t* s, const char* p, const char* endp) {
 int llhttp__on_header_field_complete(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
-  // llparse__print(p, endp, "header_field complete");
+  llparse__print(p, endp, "header_field complete");
   return 0;
 }
 
@@ -121,7 +121,7 @@ int llhttp__on_header_value(llparse_t* s, const char* p, const char* endp) {
 int llhttp__on_header_value_complete(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;
-  // llparse__print(p, endp, "header_value complete");
+  llparse__print(p, endp, "header_value complete");
   return 0;
 }
 

--- a/test/request/connection.md
+++ b/test/request/connection.md
@@ -16,8 +16,11 @@ Connection: keep-alive
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=10 span[header_value]="keep-alive"
+off=43 header_value complete
 off=45 headers complete method=4 v=1/1 flags=1 content_length=0
 off=45 message complete
 ```
@@ -38,14 +41,20 @@ Connection: keep-alive
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=10 span[header_value]="keep-alive"
+off=43 header_value complete
 off=45 headers complete method=4 v=1/1 flags=1 content_length=0
 off=45 message complete
 off=45 message begin
 off=49 len=4 span[url]="/url"
+off=54 url complete
 off=64 len=10 span[header_field]="Connection"
+off=75 header_field complete
 off=76 len=10 span[header_value]="keep-alive"
+off=88 header_value complete
 off=90 headers complete method=4 v=1/1 flags=1 content_length=0
 off=90 message complete
 ```
@@ -64,6 +73,7 @@ PUT /url HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=21 headers complete method=4 v=1/0 flags=0 content_length=0
 off=21 message complete
 off=22 error code=5 reason="Data after `Connection: close`"
@@ -88,14 +98,20 @@ Transfer-Encoding: chunked
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=1 span[header_value]="0"
+off=38 header_value complete
 off=40 headers complete method=4 v=1/0 flags=20 content_length=0
 off=40 message complete
 off=40 message begin
 off=44 len=4 span[url]="/url"
+off=49 url complete
 off=59 len=17 span[header_field]="Transfer-Encoding"
+off=77 header_field complete
 off=78 len=7 span[header_value]="chunked"
+off=87 header_value complete
 off=89 headers complete method=4 v=1/1 flags=208 content_length=0
 ```
 
@@ -117,17 +133,25 @@ _Note the trailing CRLF above_
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
 off=23 len=15 span[header_value]="www.example.com"
+off=40 header_value complete
 off=40 len=12 span[header_field]="Content-Type"
+off=53 header_field complete
 off=54 len=33 span[header_value]="application/x-www-form-urlencoded"
+off=89 header_value complete
 off=89 len=14 span[header_field]="Content-Length"
+off=104 header_field complete
 off=105 len=1 span[header_value]="4"
+off=108 header_value complete
 off=110 headers complete method=3 v=1/1 flags=20 content_length=4
 off=110 len=4 span[body]="q=42"
 off=114 message complete
 off=118 message begin
 off=122 len=1 span[url]="/"
+off=124 url complete
 ```
 
 ### Not treating `\r` as `-`
@@ -143,7 +167,9 @@ Connection: keep\ralive
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=4 span[header_value]="keep"
 off=36 error code=3 reason="Missing expected LF after header value"
 ```
@@ -163,8 +189,11 @@ Connection: close
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=5 span[header_value]="close"
+off=38 header_value complete
 off=40 headers complete method=4 v=1/1 flags=2 content_length=0
 off=40 message complete
 ```
@@ -190,14 +219,23 @@ _Note the trailing CRLF above_
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
 off=23 len=15 span[header_value]="www.example.com"
+off=40 header_value complete
 off=40 len=12 span[header_field]="Content-Type"
+off=53 header_field complete
 off=54 len=33 span[header_value]="application/x-www-form-urlencoded"
+off=89 header_value complete
 off=89 len=14 span[header_field]="Content-Length"
+off=104 header_field complete
 off=105 len=1 span[header_value]="4"
+off=108 header_value complete
 off=108 len=10 span[header_field]="Connection"
+off=119 header_field complete
 off=120 len=5 span[header_value]="close"
+off=127 header_value complete
 off=129 headers complete method=3 v=1/1 flags=22 content_length=4
 off=129 len=4 span[body]="q=42"
 off=133 message complete
@@ -225,19 +263,29 @@ _Note the trailing CRLF above_
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
 off=23 len=15 span[header_value]="www.example.com"
+off=40 header_value complete
 off=40 len=12 span[header_field]="Content-Type"
+off=53 header_field complete
 off=54 len=33 span[header_value]="application/x-www-form-urlencoded"
+off=89 header_value complete
 off=89 len=14 span[header_field]="Content-Length"
+off=104 header_field complete
 off=105 len=1 span[header_value]="4"
+off=108 header_value complete
 off=108 len=10 span[header_field]="Connection"
+off=119 header_field complete
 off=120 len=5 span[header_value]="close"
+off=127 header_value complete
 off=129 headers complete method=3 v=1/1 flags=22 content_length=4
 off=129 len=4 span[body]="q=42"
 off=133 message complete
 off=137 message begin
 off=141 len=1 span[url]="/"
+off=143 url complete
 ```
 
 ## Parsing multiple tokens
@@ -255,8 +303,11 @@ Connection: close, token, upgrade, token, keep-alive
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=40 span[header_value]="close, token, upgrade, token, keep-alive"
+off=73 header_value complete
 off=75 headers complete method=4 v=1/1 flags=7 content_length=0
 off=75 message complete
 ```
@@ -281,21 +332,36 @@ Hot diggity dogg
 ```log
 off=0 message begin
 off=4 len=5 span[url]="/demo"
+off=10 url complete
 off=20 len=4 span[header_field]="Host"
+off=25 header_field complete
 off=26 len=11 span[header_value]="example.com"
+off=39 header_value complete
 off=39 len=10 span[header_field]="Connection"
+off=50 header_field complete
 off=51 len=10 span[header_value]="Something,"
 off=63 len=21 span[header_value]=" Upgrade, ,Keep-Alive"
+off=86 header_value complete
 off=86 len=18 span[header_field]="Sec-WebSocket-Key2"
+off=105 header_field complete
 off=106 len=18 span[header_value]="12998 5 Y3 1  .P00"
+off=126 header_value complete
 off=126 len=22 span[header_field]="Sec-WebSocket-Protocol"
+off=149 header_field complete
 off=150 len=6 span[header_value]="sample"
+off=158 header_value complete
 off=158 len=7 span[header_field]="Upgrade"
+off=166 header_field complete
 off=167 len=9 span[header_value]="WebSocket"
+off=178 header_value complete
 off=178 len=18 span[header_field]="Sec-WebSocket-Key1"
+off=197 header_field complete
 off=198 len=20 span[header_value]="4 @1  46546xW%0l 1 5"
+off=220 header_value complete
 off=220 len=6 span[header_field]="Origin"
+off=227 header_field complete
 off=228 len=18 span[header_value]="http://example.com"
+off=248 header_value complete
 off=250 headers complete method=1 v=1/1 flags=15 content_length=0
 off=250 message complete
 off=250 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -315,10 +381,15 @@ Hot diggity dogg
 ```log
 off=0 message begin
 off=4 len=5 span[url]="/demo"
+off=10 url complete
 off=20 len=10 span[header_field]="Connection"
+off=31 header_field complete
 off=32 len=19 span[header_value]="keep-alive, upgrade"
+off=53 header_value complete
 off=53 len=7 span[header_field]="Upgrade"
+off=61 header_field complete
 off=62 len=9 span[header_value]="WebSocket"
+off=73 header_value complete
 off=75 headers complete method=1 v=1/1 flags=15 content_length=0
 off=75 message complete
 off=75 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -338,11 +409,16 @@ Hot diggity dogg
 ```log
 off=0 message begin
 off=4 len=5 span[url]="/demo"
+off=10 url complete
 off=20 len=10 span[header_field]="Connection"
+off=31 header_field complete
 off=32 len=12 span[header_value]="keep-alive, "
 off=46 len=8 span[header_value]=" upgrade"
+off=56 header_value complete
 off=56 len=7 span[header_field]="Upgrade"
+off=64 header_field complete
 off=65 len=9 span[header_value]="WebSocket"
+off=76 header_value complete
 off=78 headers complete method=1 v=1/1 flags=15 content_length=0
 off=78 message complete
 off=78 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -364,10 +440,15 @@ Upgrade: ws
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=7 span[header_value]="upgrade"
+off=40 header_value complete
 off=40 len=7 span[header_field]="Upgrade"
+off=48 header_field complete
 off=49 len=2 span[header_value]="ws"
+off=53 header_value complete
 off=55 headers complete method=4 v=1/1 flags=14 content_length=0
 off=55 message complete
 off=55 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -388,12 +469,19 @@ abcdefgh
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=10 span[header_field]="Connection"
+off=30 header_field complete
 off=31 len=7 span[header_value]="upgrade"
+off=40 header_value complete
 off=40 len=14 span[header_field]="Content-Length"
+off=55 header_field complete
 off=56 len=1 span[header_value]="4"
+off=59 header_value complete
 off=59 len=7 span[header_field]="Upgrade"
+off=67 header_field complete
 off=68 len=2 span[header_value]="ws"
+off=72 header_value complete
 off=74 headers complete method=4 v=1/1 flags=34 content_length=4
 off=74 len=4 span[body]="abcd"
 off=78 message complete
@@ -419,20 +507,35 @@ Hot diggity dogg
 ```log
 off=0 message begin
 off=4 len=5 span[url]="/demo"
+off=10 url complete
 off=20 len=4 span[header_field]="Host"
+off=25 header_field complete
 off=26 len=11 span[header_value]="example.com"
+off=39 header_value complete
 off=39 len=10 span[header_field]="Connection"
+off=50 header_field complete
 off=51 len=7 span[header_value]="Upgrade"
+off=60 header_value complete
 off=60 len=18 span[header_field]="Sec-WebSocket-Key2"
+off=79 header_field complete
 off=80 len=18 span[header_value]="12998 5 Y3 1  .P00"
+off=100 header_value complete
 off=100 len=22 span[header_field]="Sec-WebSocket-Protocol"
+off=123 header_field complete
 off=124 len=6 span[header_value]="sample"
+off=132 header_value complete
 off=132 len=7 span[header_field]="Upgrade"
+off=140 header_field complete
 off=141 len=9 span[header_value]="WebSocket"
+off=152 header_value complete
 off=152 len=18 span[header_field]="Sec-WebSocket-Key1"
+off=171 header_field complete
 off=172 len=20 span[header_value]="4 @1  46546xW%0l 1 5"
+off=194 header_value complete
 off=194 len=6 span[header_field]="Origin"
+off=201 header_field complete
 off=202 len=18 span[header_value]="http://example.com"
+off=222 header_value complete
 off=224 headers complete method=1 v=1/1 flags=14 content_length=0
 off=224 message complete
 off=224 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -455,14 +558,23 @@ Hot diggity dogg
 ```log
 off=0 message begin
 off=5 len=5 span[url]="/demo"
+off=11 url complete
 off=21 len=4 span[header_field]="Host"
+off=26 header_field complete
 off=27 len=11 span[header_value]="example.com"
+off=40 header_value complete
 off=40 len=10 span[header_field]="Connection"
+off=51 header_field complete
 off=52 len=7 span[header_value]="Upgrade"
+off=61 header_value complete
 off=61 len=7 span[header_field]="Upgrade"
+off=69 header_field complete
 off=70 len=8 span[header_value]="HTTP/2.0"
+off=80 header_value complete
 off=80 len=14 span[header_field]="Content-Length"
+off=95 header_field complete
 off=96 len=2 span[header_value]="15"
+off=100 header_value complete
 off=102 headers complete method=3 v=1/1 flags=34 content_length=15
 off=102 len=15 span[body]="sweet post body"
 off=117 message complete

--- a/test/request/content-length.md
+++ b/test/request/content-length.md
@@ -14,8 +14,11 @@ abc
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=3 span[header_value]="003"
+off=40 header_value complete
 off=42 headers complete method=4 v=1/1 flags=20 content_length=3
 off=42 len=3 span[body]="abc"
 off=45 message complete
@@ -43,10 +46,15 @@ abc
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=3 span[header_value]="003"
+off=40 header_value complete
 off=40 len=4 span[header_field]="Ohai"
+off=45 header_field complete
 off=46 len=5 span[header_value]="world"
+off=53 header_value complete
 off=55 headers complete method=4 v=1/1 flags=20 content_length=3
 off=55 len=3 span[body]="abc"
 off=58 message complete
@@ -64,7 +72,9 @@ Content-Length: 1000000000000000000000
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=21 span[header_value]="100000000000000000000"
 off=56 error code=11 reason="Content-Length overflow"
 ```
@@ -82,9 +92,13 @@ Content-Length: 2
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=1 span[header_value]="1"
+off=38 header_value complete
 off=38 len=14 span[header_field]="Content-Length"
+off=53 header_field complete
 off=54 error code=4 reason="Duplicate Content-Length"
 ```
 
@@ -102,10 +116,15 @@ Transfer-Encoding: identity
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=1 span[header_value]="1"
+off=38 header_value complete
 off=38 len=17 span[header_field]="Transfer-Encoding"
+off=56 header_field complete
 off=57 len=8 span[header_value]="identity"
+off=67 header_value complete
 off=69 error code=4 reason="Content-Length can't be present with Transfer-Encoding"
 ```
 
@@ -123,10 +142,15 @@ Transfer-Encoding: chunked
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=14 span[header_field]="Content-Length"
+off=34 header_field complete
 off=35 len=1 span[header_value]="1"
+off=38 header_value complete
 off=38 len=17 span[header_field]="Transfer-Encoding"
+off=56 header_field complete
 off=57 len=7 span[header_value]="chunked"
+off=66 header_value complete
 off=68 headers complete method=4 v=1/1 flags=228 content_length=1
 ```
 
@@ -143,8 +167,11 @@ HELLO
 ```log
 off=0 message begin
 off=4 len=36 span[url]="/get_funky_content_length_body_hello"
+off=41 url complete
 off=51 len=14 span[header_field]="conTENT-Length"
+off=66 header_field complete
 off=67 len=1 span[header_value]="5"
+off=70 header_value complete
 off=72 headers complete method=1 v=1/0 flags=20 content_length=5
 off=72 len=5 span[body]="HELLO"
 off=77 message complete
@@ -163,8 +190,11 @@ Content-Length:  42
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=14 span[header_field]="Content-Length"
+off=32 header_field complete
 off=34 len=3 span[header_value]="42 "
+off=39 header_value complete
 off=41 headers complete method=3 v=1/1 flags=20 content_length=42
 ```
 
@@ -181,7 +211,9 @@ Content-Length: 4 2
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=14 span[header_field]="Content-Length"
+off=32 header_field complete
 off=33 len=2 span[header_value]="4 "
 off=35 error code=11 reason="Invalid character in Content-Length"
 ```
@@ -199,7 +231,9 @@ Content-Length: 13 37
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=14 span[header_field]="Content-Length"
+off=32 header_field complete
 off=33 len=3 span[header_value]="13 "
 off=36 error code=11 reason="Invalid character in Content-Length"
 ```
@@ -217,7 +251,9 @@ Content-Length:
 ```log
 off=0 message begin
 off=5 len=1 span[url]="/"
+off=7 url complete
 off=17 len=14 span[header_field]="Content-Length"
+off=32 header_field complete
 off=34 error code=11 reason="Empty Content-Length"
 ```
 
@@ -234,5 +270,6 @@ abc
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=26 error code=10 reason="Invalid header token"
 ```

--- a/test/request/finish.md
+++ b/test/request/finish.md
@@ -15,6 +15,7 @@ GET / HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=18 headers complete method=1 v=1/1 flags=0 content_length=0
 off=18 message complete
 off=NULL finish=0
@@ -32,7 +33,9 @@ Content-Length: 100
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=14 span[header_field]="Content-Length"
+off=31 header_field complete
 off=32 len=3 span[header_value]="100"
 off=NULL finish=2
 ```
@@ -48,6 +51,7 @@ Content-Leng
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=12 span[header_field]="Content-Leng"
 off=NULL finish=2
 ```

--- a/test/request/invalid.md
+++ b/test/request/invalid.md
@@ -14,6 +14,7 @@ Host: example.com
 ```log
 off=0 message begin
 off=4 len=18 span[url]="/music/sweet/music"
+off=23 url complete
 off=27 error code=8 reason="Expected SOURCE method for ICE/x.x request"
 ```
 
@@ -30,6 +31,7 @@ Host: example.com
 ```log
 off=0 message begin
 off=4 len=18 span[url]="/music/sweet/music"
+off=23 url complete
 off=24 error code=8 reason="Expected HTTP/"
 ```
 
@@ -46,6 +48,7 @@ Host: example.com
 ```log
 off=0 message begin
 off=4 len=18 span[url]="/music/sweet/music"
+off=23 url complete
 off=28 error code=8 reason="Invalid method for RTSP/x.x request"
 ```
 
@@ -62,6 +65,7 @@ Host: example.com
 ```log
 off=0 message begin
 off=9 len=18 span[url]="/music/sweet/music"
+off=28 url complete
 off=33 error code=8 reason="Invalid method for HTTP/x.x request"
 ```
 
@@ -78,7 +82,9 @@ Foo: 1\rBar: 2
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=3 span[header_field]="Foo"
+off=20 header_field complete
 off=21 len=1 span[header_value]="1"
 off=23 error code=3 reason="Missing expected LF after header value"
 ```
@@ -96,6 +102,7 @@ Fo@: Failure
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=18 error code=10 reason="Invalid header token"
 ```
 
@@ -112,6 +119,7 @@ Foo\01\test: Bar
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=19 error code=10 reason="Invalid header token"
 ```
 
@@ -143,6 +151,7 @@ name
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=20 error code=10 reason="Invalid header token"
 ```
 
@@ -161,8 +170,11 @@ Accept-Encoding: gzip
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=4 span[header_field]="Host"
+off=21 header_field complete
 off=22 len=15 span[header_value]="www.example.com"
+off=39 header_value complete
 off=49 error code=10 reason="Invalid header token"
 ```
 
@@ -181,7 +193,10 @@ Accept-Encoding: gzip
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=4 span[header_field]="Host"
+off=21 header_field complete
 off=22 len=15 span[header_value]="www.example.com"
+off=39 header_value complete
 off=52 error code=10 reason="Invalid header token"
 ```

--- a/test/request/lenient-headers.md
+++ b/test/request/lenient-headers.md
@@ -16,8 +16,11 @@ Header1: \f
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=7 span[header_field]="Header1"
+off=27 header_field complete
 off=28 len=1 span[header_value]="\f"
+off=31 header_value complete
 off=33 headers complete method=1 v=1/1 flags=0 content_length=0
 off=33 message complete
 ```
@@ -39,14 +42,20 @@ Header1: \f
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=7 span[header_field]="Header1"
+off=27 header_field complete
 off=28 len=4 span[header_value]="Okay"
+off=34 header_value complete
 off=36 headers complete method=1 v=1/1 flags=0 content_length=0
 off=36 message complete
 off=38 message begin
 off=42 len=4 span[url]="/url"
+off=47 url complete
 off=57 len=7 span[header_field]="Header1"
+off=65 header_field complete
 off=66 len=1 span[header_value]="\f"
+off=69 header_value complete
 off=71 headers complete method=1 v=1/1 flags=0 content_length=0
 off=71 message complete
 ```
@@ -65,6 +74,8 @@ Header1: \f
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=7 span[header_field]="Header1"
+off=27 header_field complete
 off=28 error code=10 reason="Invalid header value char"
 ```

--- a/test/request/method.md
+++ b/test/request/method.md
@@ -13,6 +13,7 @@ REPORT /test HTTP/1.1
 ```log
 off=0 message begin
 off=7 len=5 span[url]="/test"
+off=13 url complete
 off=25 headers complete method=20 v=1/1 flags=0 content_length=0
 off=25 message complete
 ```
@@ -32,10 +33,15 @@ and yet even more data
 ```log
 off=0 message begin
 off=8 len=24 span[url]="0-home0.netscape.com:443"
+off=33 url complete
 off=43 len=10 span[header_field]="User-agent"
+off=54 header_field complete
 off=55 len=12 span[header_value]="Mozilla/1.1N"
+off=69 header_value complete
 off=69 len=19 span[header_field]="Proxy-authorization"
+off=89 header_field complete
 off=90 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
+off=114 header_value complete
 off=116 headers complete method=5 v=1/0 flags=0 content_length=0
 off=116 message complete
 off=116 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -55,10 +61,15 @@ Proxy-authorization: basic aGVsbG86d29ybGQ=
 ```log
 off=0 message begin
 off=8 len=22 span[url]="HOME0.NETSCAPE.COM:443"
+off=31 url complete
 off=41 len=10 span[header_field]="User-agent"
+off=52 header_field complete
 off=53 len=12 span[header_value]="Mozilla/1.1N"
+off=67 header_value complete
 off=67 len=19 span[header_field]="Proxy-authorization"
+off=87 header_field complete
 off=88 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
+off=112 header_value complete
 off=114 headers complete method=5 v=1/0 flags=0 content_length=0
 off=114 message complete
 off=114 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -79,12 +90,19 @@ blarfcicle"
 ```log
 off=0 message begin
 off=8 len=15 span[url]="foo.bar.com:443"
+off=24 url complete
 off=34 len=10 span[header_field]="User-agent"
+off=45 header_field complete
 off=46 len=12 span[header_value]="Mozilla/1.1N"
+off=60 header_value complete
 off=60 len=19 span[header_field]="Proxy-authorization"
+off=80 header_field complete
 off=81 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
+off=105 header_value complete
 off=105 len=14 span[header_field]="Content-Length"
+off=120 header_field complete
 off=121 len=2 span[header_value]="10"
+off=125 header_value complete
 off=127 headers complete method=5 v=1/0 flags=20 content_length=10
 off=127 message complete
 off=127 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -105,12 +123,19 @@ ST: "ssdp:all"
 ```log
 off=0 message begin
 off=9 len=1 span[url]="*"
+off=11 url complete
 off=21 len=4 span[header_field]="HOST"
+off=26 header_field complete
 off=27 len=20 span[header_value]="239.255.255.250:1900"
+off=49 header_value complete
 off=49 len=3 span[header_field]="MAN"
+off=53 header_field complete
 off=54 len=15 span[header_value]=""ssdp:discover""
+off=71 header_value complete
 off=71 len=2 span[header_field]="ST"
+off=74 header_field complete
 off=75 len=10 span[header_value]=""ssdp:all""
+off=87 header_value complete
 off=89 headers complete method=24 v=1/1 flags=0 content_length=0
 off=89 message complete
 ```
@@ -131,14 +156,23 @@ cccccccccc
 ```log
 off=0 message begin
 off=6 len=9 span[url]="/file.txt"
+off=16 url complete
 off=26 len=4 span[header_field]="Host"
+off=31 header_field complete
 off=32 len=15 span[header_value]="www.example.com"
+off=49 header_value complete
 off=49 len=12 span[header_field]="Content-Type"
+off=62 header_field complete
 off=63 len=19 span[header_value]="application/example"
+off=84 header_value complete
 off=84 len=8 span[header_field]="If-Match"
+off=93 header_field complete
 off=94 len=11 span[header_value]=""e0023aa4e""
+off=107 header_value complete
 off=107 len=14 span[header_field]="Content-Length"
+off=122 header_field complete
 off=123 len=2 span[header_value]="10"
+off=127 header_value complete
 off=129 headers complete method=28 v=1/1 flags=20 content_length=10
 off=129 len=10 span[body]="cccccccccc"
 off=139 message complete
@@ -157,8 +191,11 @@ Host: www.example.com
 ```log
 off=0 message begin
 off=6 len=9 span[url]="/file.txt"
+off=16 url complete
 off=26 len=4 span[header_field]="Host"
+off=31 header_field complete
 off=32 len=15 span[header_value]="www.example.com"
+off=49 header_value complete
 off=51 headers complete method=29 v=1/1 flags=0 content_length=0
 off=51 message complete
 ```
@@ -176,8 +213,11 @@ Host: www.example.com
 ```log
 off=0 message begin
 off=7 len=1 span[url]="/"
+off=9 url complete
 off=19 len=4 span[header_field]="Host"
+off=24 header_field complete
 off=25 len=15 span[header_value]="www.example.com"
+off=42 header_value complete
 off=44 headers complete method=14 v=1/1 flags=0 content_length=0
 off=44 message complete
 ```
@@ -197,12 +237,19 @@ Link: <http://example.com/profiles/sally>; rel="tag"
 ```log
 off=0 message begin
 off=5 len=18 span[url]="/images/my_dog.jpg"
+off=24 url complete
 off=34 len=4 span[header_field]="Host"
+off=39 header_field complete
 off=40 len=11 span[header_value]="example.com"
+off=53 header_value complete
 off=53 len=4 span[header_field]="Link"
+off=58 header_field complete
 off=59 len=44 span[header_value]="<http://example.com/profiles/joe>; rel="tag""
+off=105 header_value complete
 off=105 len=4 span[header_field]="Link"
+off=110 header_field complete
 off=111 len=46 span[header_value]="<http://example.com/profiles/sally>; rel="tag""
+off=159 header_value complete
 off=161 headers complete method=31 v=1/1 flags=0 content_length=0
 off=161 message complete
 ```
@@ -221,10 +268,15 @@ Link: <http://example.com/profiles/sally>; rel="tag"
 ```log
 off=0 message begin
 off=7 len=18 span[url]="/images/my_dog.jpg"
+off=26 url complete
 off=36 len=4 span[header_field]="Host"
+off=41 header_field complete
 off=42 len=11 span[header_value]="example.com"
+off=55 header_value complete
 off=55 len=4 span[header_field]="Link"
+off=60 header_field complete
 off=61 len=46 span[header_value]="<http://example.com/profiles/sally>; rel="tag""
+off=109 header_value complete
 off=111 headers complete method=32 v=1/1 flags=0 content_length=0
 off=111 message complete
 ```
@@ -242,8 +294,11 @@ Host: example.com
 ```log
 off=0 message begin
 off=7 len=18 span[url]="/music/sweet/music"
+off=26 url complete
 off=36 len=4 span[header_field]="Host"
+off=41 header_field complete
 off=42 len=11 span[header_value]="example.com"
+off=55 header_value complete
 off=57 headers complete method=33 v=1/1 flags=0 content_length=0
 off=57 message complete
 ```
@@ -261,8 +316,11 @@ Host: example.com
 ```log
 off=0 message begin
 off=7 len=18 span[url]="/music/sweet/music"
+off=26 url complete
 off=35 len=4 span[header_field]="Host"
+off=40 header_field complete
 off=41 len=11 span[header_value]="example.com"
+off=54 header_value complete
 off=56 headers complete method=33 v=1/0 flags=0 content_length=0
 off=56 message complete
 ```
@@ -282,8 +340,11 @@ Host: example.com
 ```log
 off=0 message begin
 off=8 len=18 span[url]="/music/sweet/music"
+off=27 url complete
 off=37 len=4 span[header_field]="Host"
+off=42 header_field complete
 off=43 len=11 span[header_value]="example.com"
+off=56 header_value complete
 off=58 headers complete method=6 v=1/0 flags=0 content_length=0
 off=58 message complete
 ```
@@ -301,8 +362,11 @@ Host: example.com
 ```log
 off=0 message begin
 off=9 len=18 span[url]="/music/sweet/music"
+off=28 url complete
 off=38 len=4 span[header_field]="Host"
+off=43 header_field complete
 off=44 len=11 span[header_value]="example.com"
+off=57 header_value complete
 off=59 headers complete method=36 v=1/0 flags=0 content_length=0
 off=59 message complete
 ```
@@ -321,5 +385,6 @@ SM
 ```log
 off=0 message begin
 off=4 len=1 span[url]="*"
+off=6 url complete
 off=24 error code=22 reason="Pause on PRI/Upgrade"
 ```

--- a/test/request/sample.md
+++ b/test/request/sample.md
@@ -17,10 +17,15 @@ Header2:\t Value2
 ```log
 off=0 message begin
 off=8 len=4 span[url]="/url"
+off=13 url complete
 off=23 len=7 span[header_field]="Header1"
+off=31 header_field complete
 off=32 len=6 span[header_value]="Value1"
+off=40 header_value complete
 off=40 len=7 span[header_field]="Header2"
+off=48 header_field complete
 off=50 len=6 span[header_value]="Value2"
+off=58 header_value complete
 off=60 headers complete method=6 v=1/1 flags=0 content_length=0
 off=60 message complete
 ```
@@ -42,6 +47,7 @@ HEAD /url HTTP/1.1
 ```log
 off=0 message begin
 off=5 len=4 span[url]="/url"
+off=10 url complete
 off=22 headers complete method=2 v=1/1 flags=0 content_length=0
 off=22 message complete
 ```
@@ -61,12 +67,19 @@ Accept: */*
 ```log
 off=0 message begin
 off=4 len=5 span[url]="/test"
+off=10 url complete
 off=20 len=10 span[header_field]="User-Agent"
+off=31 header_field complete
 off=32 len=85 span[header_value]="curl/7.18.0 (i486-pc-linux-gnu) libcurl/7.18.0 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.1"
+off=119 header_value complete
 off=119 len=4 span[header_field]="Host"
+off=124 header_field complete
 off=125 len=12 span[header_value]="0.0.0.0=5000"
+off=139 header_value complete
 off=139 len=6 span[header_field]="Accept"
+off=146 header_field complete
 off=147 len=3 span[header_value]="*/*"
+off=152 header_value complete
 off=154 headers complete method=1 v=1/1 flags=0 content_length=0
 off=154 message complete
 ```
@@ -91,22 +104,39 @@ Connection: keep-alive
 ```log
 off=0 message begin
 off=4 len=12 span[url]="/favicon.ico"
+off=17 url complete
 off=27 len=4 span[header_field]="Host"
+off=32 header_field complete
 off=33 len=12 span[header_value]="0.0.0.0=5000"
+off=47 header_value complete
 off=47 len=10 span[header_field]="User-Agent"
+off=58 header_field complete
 off=59 len=76 span[header_value]="Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9) Gecko/2008061015 Firefox/3.0"
+off=137 header_value complete
 off=137 len=6 span[header_field]="Accept"
+off=144 header_field complete
 off=145 len=63 span[header_value]="text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+off=210 header_value complete
 off=210 len=15 span[header_field]="Accept-Language"
+off=226 header_field complete
 off=227 len=14 span[header_value]="en-us,en;q=0.5"
+off=243 header_value complete
 off=243 len=15 span[header_field]="Accept-Encoding"
+off=259 header_field complete
 off=260 len=12 span[header_value]="gzip,deflate"
+off=274 header_value complete
 off=274 len=14 span[header_field]="Accept-Charset"
+off=289 header_field complete
 off=290 len=30 span[header_value]="ISO-8859-1,utf-8;q=0.7,*;q=0.7"
+off=322 header_value complete
 off=322 len=10 span[header_field]="Keep-Alive"
+off=333 header_field complete
 off=334 len=3 span[header_value]="300"
+off=339 header_value complete
 off=339 len=10 span[header_field]="Connection"
+off=350 header_field complete
 off=351 len=10 span[header_value]="keep-alive"
+off=363 header_value complete
 off=365 headers complete method=1 v=1/1 flags=1 content_length=0
 off=365 message complete
 ```
@@ -124,8 +154,11 @@ aaaaaaaaaaaaa:++++++++++
 ```log
 off=0 message begin
 off=4 len=9 span[url]="/dumbpack"
+off=14 url complete
 off=24 len=13 span[header_field]="aaaaaaaaaaaaa"
+off=38 header_field complete
 off=38 len=10 span[header_value]="++++++++++"
+off=50 header_value complete
 off=52 headers complete method=1 v=1/1 flags=0 content_length=0
 off=52 message complete
 ```
@@ -142,6 +175,7 @@ GET /get_no_headers_no_body/world HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=29 span[url]="/get_no_headers_no_body/world"
+off=34 url complete
 off=46 headers complete method=1 v=1/1 flags=0 content_length=0
 off=46 message complete
 ```
@@ -159,8 +193,11 @@ Accept: */*
 ```log
 off=0 message begin
 off=4 len=23 span[url]="/get_one_header_no_body"
+off=28 url complete
 off=38 len=6 span[header_field]="Accept"
+off=45 header_field complete
 off=46 len=3 span[header_value]="*/*"
+off=51 header_value complete
 off=53 headers complete method=1 v=1/1 flags=0 content_length=0
 off=53 message complete
 ```
@@ -183,12 +220,19 @@ Accept: */*
 ```log
 off=0 message begin
 off=4 len=5 span[url]="/test"
+off=10 url complete
 off=20 len=4 span[header_field]="Host"
+off=25 header_field complete
 off=26 len=12 span[header_value]="0.0.0.0:5000"
+off=40 header_value complete
 off=40 len=10 span[header_field]="User-Agent"
+off=51 header_field complete
 off=52 len=15 span[header_value]="ApacheBench/2.3"
+off=69 header_value complete
 off=69 len=6 span[header_field]="Accept"
+off=76 header_field complete
 off=77 len=3 span[header_value]="*/*"
+off=82 header_value complete
 off=84 headers complete method=1 v=1/0 flags=0 content_length=0
 off=84 message complete
 ```
@@ -208,6 +252,7 @@ will send an extra CRLF before the next request.
 ```log
 off=2 message begin
 off=6 len=5 span[url]="/test"
+off=12 url complete
 off=24 headers complete method=1 v=1/1 flags=0 content_length=0
 off=24 message complete
 ```
@@ -224,6 +269,7 @@ GET /
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=7 url complete
 off=9 headers complete method=1 v=0/9 flags=0 content_length=0
 off=9 message complete
 ```
@@ -253,21 +299,32 @@ Connection:
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=5 span[header_field]="Line1"
+off=22 header_field complete
 off=25 len=3 span[header_value]="abc"
 off=30 len=4 span[header_value]="\tdef"
 off=36 len=4 span[header_value]=" ghi"
 off=42 len=5 span[header_value]="\t\tjkl"
 off=49 len=6 span[header_value]="  mno "
 off=57 len=6 span[header_value]="\t \tqrs"
+off=65 header_value complete
 off=65 len=5 span[header_field]="Line2"
+off=71 header_field complete
 off=74 len=6 span[header_value]="line2\t"
+off=82 header_value complete
 off=82 len=5 span[header_field]="Line3"
+off=88 header_field complete
 off=91 len=5 span[header_value]="line3"
+off=98 header_value complete
 off=98 len=5 span[header_field]="Line4"
+off=104 header_field complete
 off=110 len=0 span[header_value]=""
+off=110 header_value complete
 off=110 len=10 span[header_field]="Connection"
+off=121 header_field complete
 off=124 len=5 span[header_value]="close"
+off=131 header_value complete
 off=133 headers complete method=1 v=1/1 flags=2 content_length=0
 off=133 message complete
 ```
@@ -296,21 +353,32 @@ Connection:\n\
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=15 len=5 span[header_field]="Line1"
+off=21 header_field complete
 off=24 len=3 span[header_value]="abc"
 off=28 len=4 span[header_value]="\tdef"
 off=33 len=4 span[header_value]=" ghi"
 off=38 len=5 span[header_value]="\t\tjkl"
 off=44 len=6 span[header_value]="  mno "
 off=51 len=6 span[header_value]="\t \tqrs"
+off=58 header_value complete
 off=58 len=5 span[header_field]="Line2"
+off=64 header_field complete
 off=67 len=6 span[header_value]="line2\t"
+off=74 header_value complete
 off=74 len=5 span[header_field]="Line3"
+off=80 header_field complete
 off=82 len=5 span[header_value]="line3"
+off=88 header_value complete
 off=88 len=5 span[header_field]="Line4"
+off=94 header_field complete
 off=98 len=0 span[header_value]=""
+off=98 header_value complete
 off=98 len=10 span[header_field]="Connection"
+off=109 header_field complete
 off=111 len=5 span[header_value]="close"
+off=117 header_value complete
 off=118 headers complete method=1 v=1/1 flags=2 content_length=0
 off=118 message complete
 ```
@@ -328,8 +396,11 @@ Header1: Value1
 ```log
 off=2 message begin
 off=6 len=4 span[url]="/url"
+off=11 url complete
 off=21 len=7 span[header_field]="Header1"
+off=29 header_field complete
 off=30 len=6 span[header_value]="Value1"
+off=38 header_value complete
 off=40 headers complete method=1 v=1/1 flags=0 content_length=0
 off=40 message complete
 ```
@@ -349,8 +420,11 @@ Test: Düsseldorf
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=4 span[header_field]="Test"
+off=21 header_field complete
 off=22 len=11 span[header_value]="Düsseldorf"
+off=35 header_value complete
 off=37 headers complete method=1 v=1/1 flags=0 content_length=0
 off=37 message complete
 ```
@@ -371,10 +445,15 @@ Header2: \xffValue2
 ```log
 off=0 message begin
 off=8 len=4 span[url]="/url"
+off=13 url complete
 off=23 len=7 span[header_field]="Header1"
+off=31 header_field complete
 off=32 len=6 span[header_value]="Value1"
+off=40 header_value complete
 off=40 len=7 span[header_field]="Header2"
+off=48 header_field complete
 off=49 len=8 span[header_value]="ÿValue2"
+off=59 header_value complete
 off=61 headers complete method=6 v=1/1 flags=0 content_length=0
 off=61 message complete
 ```
@@ -425,7 +504,9 @@ X-SSL-Nonsense:   -----BEGIN CERTIFICATE-----
 ```log
 off=0 message begin
 off=4 len=1 span[url]="/"
+off=6 url complete
 off=16 len=14 span[header_field]="X-SSL-Nonsense"
+off=31 header_field complete
 off=34 len=27 span[header_value]="-----BEGIN CERTIFICATE-----"
 off=63 len=65 span[header_value]="\tMIIFbTCCBFWgAwIBAgICH4cwDQYJKoZIhvcNAQEFBQAwcDELMAkGA1UEBhMCVUsx"
 off=130 len=65 span[header_value]="\tETAPBgNVBAoTCGVTY2llbmNlMRIwEAYDVQQLEwlBdXRob3JpdHkxCzAJBgNVBAMT"
@@ -458,6 +539,7 @@ off=1873 len=65 span[header_value]="\twTC6o2xq5y0qZ03JonF7OJspEd3I5zKY3E+ov7/ZhW
 off=1940 len=65 span[header_value]="\tYhixw1aKEPzNjNowuIseVogKOLXxWI5vAi5HgXdS0/ES5gDGsABo4fqovUKlgop3"
 off=2007 len=5 span[header_value]="\tRA=="
 off=2014 len=26 span[header_value]="\t-----END CERTIFICATE-----"
+off=2042 header_value complete
 off=2044 headers complete method=1 v=1/1 flags=0 content_length=0
 off=2044 message complete
 ```

--- a/test/request/transfer-encoding.md
+++ b/test/request/transfer-encoding.md
@@ -16,8 +16,11 @@ Transfer-Encoding: chunked
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=17 span[header_field]="Transfer-Encoding"
+off=37 header_field complete
 off=38 len=7 span[header_value]="chunked"
+off=47 header_value complete
 off=49 headers complete method=4 v=1/1 flags=208 content_length=0
 ```
 
@@ -38,8 +41,11 @@ a
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=17 span[header_field]="Transfer-Encoding"
+off=37 header_field complete
 off=38 len=7 span[header_value]="chunked"
+off=47 header_value complete
 off=49 headers complete method=4 v=1/1 flags=208 content_length=0
 off=52 chunk header len=10
 off=52 len=10 span[body]="0123456789"
@@ -66,8 +72,11 @@ A
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=17 span[header_field]="Transfer-Encoding"
+off=37 header_field complete
 off=38 len=7 span[header_value]="chunked"
+off=47 header_value complete
 off=49 headers complete method=4 v=1/1 flags=208 content_length=0
 off=52 chunk header len=10
 off=52 len=10 span[body]="0123456789"
@@ -94,8 +103,11 @@ all your base are belong to us
 ```log
 off=0 message begin
 off=5 len=27 span[url]="/post_chunked_all_your_base"
+off=33 url complete
 off=43 len=17 span[header_field]="Transfer-Encoding"
+off=61 header_field complete
 off=62 len=7 span[header_value]="chunked"
+off=71 header_value complete
 off=73 headers complete method=3 v=1/1 flags=208 content_length=0
 off=77 chunk header len=30
 off=77 len=30 span[body]="all your base are belong to us"
@@ -124,8 +136,11 @@ hello
 ```log
 off=0 message begin
 off=5 len=25 span[url]="/two_chunks_mult_zero_end"
+off=31 url complete
 off=41 len=17 span[header_field]="Transfer-Encoding"
+off=59 header_field complete
 off=60 len=7 span[header_value]="chunked"
+off=69 header_value complete
 off=71 headers complete method=3 v=1/1 flags=208 content_length=0
 off=74 chunk header len=5
 off=74 len=5 span[body]="hello"
@@ -159,8 +174,11 @@ Content-Type: text/plain
 ```log
 off=0 message begin
 off=5 len=27 span[url]="/chunked_w_trailing_headers"
+off=33 url complete
 off=43 len=17 span[header_field]="Transfer-Encoding"
+off=61 header_field complete
 off=62 len=7 span[header_value]="chunked"
+off=71 header_value complete
 off=73 headers complete method=3 v=1/1 flags=208 content_length=0
 off=76 chunk header len=5
 off=76 len=5 span[body]="hello"
@@ -170,9 +188,13 @@ off=86 len=6 span[body]=" world"
 off=94 chunk complete
 off=97 chunk header len=0
 off=97 len=4 span[header_field]="Vary"
+off=102 header_field complete
 off=103 len=1 span[header_value]="*"
+off=106 header_value complete
 off=106 len=12 span[header_field]="Content-Type"
+off=119 header_field complete
 off=120 len=10 span[header_value]="text/plain"
+off=132 header_value complete
 off=134 chunk complete
 off=134 message complete
 ```
@@ -195,8 +217,11 @@ hello
 ```log
 off=0 message begin
 off=5 len=32 span[url]="/chunked_w_unicorns_after_length"
+off=38 url complete
 off=48 len=17 span[header_field]="Transfer-Encoding"
+off=66 header_field complete
 off=67 len=7 span[header_value]="chunked"
+off=76 header_value complete
 off=78 headers complete method=3 v=1/1 flags=208 content_length=0
 off=123 chunk header len=5
 off=123 len=5 span[body]="hello"
@@ -223,8 +248,11 @@ Transfer-Encoding: pigeons
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=17 span[header_field]="Transfer-Encoding"
+off=37 header_field complete
 off=38 len=7 span[header_value]="pigeons"
+off=47 header_value complete
 off=49 headers complete method=4 v=1/1 flags=200 content_length=0
 off=49 error code=15 reason="Request has invalid `Transfer-Encoding`"
 ```
@@ -244,12 +272,19 @@ World
 ```log
 off=0 message begin
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 url complete
 off=54 len=6 span[header_field]="Accept"
+off=61 header_field complete
 off=62 len=3 span[header_value]="*/*"
+off=67 header_value complete
 off=67 len=17 span[header_field]="Transfer-Encoding"
+off=85 header_field complete
 off=86 len=8 span[header_value]="identity"
+off=96 header_value complete
 off=96 len=14 span[header_field]="Content-Length"
+off=111 header_field complete
 off=112 len=1 span[header_value]="5"
+off=115 header_value complete
 off=117 error code=4 reason="Content-Length can't be present with Transfer-Encoding"
 ```
 
@@ -274,12 +309,19 @@ World
 ```log
 off=0 message begin
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 url complete
 off=54 len=6 span[header_field]="Accept"
+off=61 header_field complete
 off=62 len=3 span[header_value]="*/*"
+off=67 header_value complete
 off=67 len=17 span[header_field]="Transfer-Encoding"
+off=85 header_field complete
 off=86 len=8 span[header_value]="identity"
+off=96 header_value complete
 off=96 len=14 span[header_field]="Content-Length"
+off=111 header_field complete
 off=112 len=1 span[header_value]="1"
+off=115 header_value complete
 off=117 headers complete method=3 v=1/1 flags=220 content_length=1
 off=117 len=5 span[body]="World"
 ```
@@ -298,10 +340,15 @@ World
 ```log
 off=0 message begin
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 url complete
 off=54 len=6 span[header_field]="Accept"
+off=61 header_field complete
 off=62 len=3 span[header_value]="*/*"
+off=67 header_value complete
 off=67 len=17 span[header_field]="Transfer-Encoding"
+off=85 header_field complete
 off=86 len=16 span[header_value]="chunked, deflate"
+off=104 header_value complete
 off=106 headers complete method=3 v=1/1 flags=200 content_length=0
 off=106 error code=15 reason="Request has invalid `Transfer-Encoding`"
 ```
@@ -323,10 +370,15 @@ World
 ```log
 off=0 message begin
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 url complete
 off=54 len=6 span[header_field]="Accept"
+off=61 header_field complete
 off=62 len=3 span[header_value]="*/*"
+off=67 header_value complete
 off=67 len=17 span[header_field]="Transfer-Encoding"
+off=85 header_field complete
 off=86 len=16 span[header_value]="chunked, deflate"
+off=104 header_value complete
 off=106 headers complete method=3 v=1/1 flags=200 content_length=0
 off=106 len=5 span[body]="World"
 ```
@@ -349,10 +401,15 @@ World
 ```log
 off=0 message begin
 off=5 len=38 span[url]="/post_identity_body_world?q=search#hey"
+off=44 url complete
 off=54 len=6 span[header_field]="Accept"
+off=61 header_field complete
 off=62 len=3 span[header_value]="*/*"
+off=67 header_value complete
 off=67 len=17 span[header_field]="Transfer-Encoding"
+off=85 header_field complete
 off=86 len=16 span[header_value]="deflate, chunked"
+off=104 header_value complete
 off=106 headers complete method=3 v=1/1 flags=208 content_length=0
 off=109 chunk header len=5
 off=109 len=5 span[body]="World"
@@ -378,8 +435,11 @@ foo
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/url"
+off=9 url complete
 off=19 len=17 span[header_field]="Transfer-Encoding"
+off=37 header_field complete
 off=38 len=7 span[header_value]="chunked"
+off=47 header_value complete
 off=49 headers complete method=4 v=1/1 flags=208 content_length=0
 off=52 chunk header len=3
 off=52 len=3 span[body]="foo"

--- a/test/request/uri.md
+++ b/test/request/uri.md
@@ -13,6 +13,7 @@ GET /with_"lovely"_quotes?foo=\"bar\" HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=33 span[url]="/with_"lovely"_quotes?foo=\"bar\""
+off=38 url complete
 off=50 headers complete method=1 v=1/1 flags=0 content_length=0
 off=50 message complete
 ```
@@ -31,6 +32,7 @@ GET /test.cgi?foo=bar?baz HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=21 span[url]="/test.cgi?foo=bar?baz"
+off=26 url complete
 off=38 headers complete method=1 v=1/1 flags=0 content_length=0
 off=38 message complete
 ```
@@ -47,6 +49,7 @@ GET http://hypnotoad.org?hail=all HTTP/1.1\r\n
 ```log
 off=0 message begin
 off=4 len=29 span[url]="http://hypnotoad.org?hail=all"
+off=34 url complete
 off=46 headers complete method=1 v=1/1 flags=0 content_length=0
 off=46 message complete
 ```
@@ -63,6 +66,7 @@ GET http://hypnotoad.org:1234?hail=all HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=34 span[url]="http://hypnotoad.org:1234?hail=all"
+off=39 url complete
 off=51 headers complete method=1 v=1/1 flags=0 content_length=0
 off=51 message complete
 ```
@@ -83,6 +87,7 @@ GET /test.cgi?query=| HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=17 span[url]="/test.cgi?query=|"
+off=22 url complete
 off=34 headers complete method=1 v=1/1 flags=0 content_length=0
 off=34 message complete
 ```
@@ -99,6 +104,7 @@ GET http://hypnotoad.org:1234 HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=25 span[url]="http://hypnotoad.org:1234"
+off=30 url complete
 off=42 headers complete method=1 v=1/1 flags=0 content_length=0
 off=42 message complete
 ```
@@ -116,8 +122,11 @@ Host: github.com
 ```log
 off=0 message begin
 off=4 len=36 span[url]="/δ¶/δt/космос/pope?q=1#narf"
+off=41 url complete
 off=51 len=4 span[header_field]="Host"
+off=56 header_field complete
 off=57 len=10 span[header_value]="github.com"
+off=69 header_value complete
 off=71 headers complete method=1 v=1/1 flags=0 content_length=0
 off=71 message complete
 ```
@@ -149,6 +158,7 @@ GET /forums/1/topics/2375?page=1#posts-17408 HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=40 span[url]="/forums/1/topics/2375?page=1#posts-17408"
+off=45 url complete
 off=57 headers complete method=1 v=1/1 flags=0 content_length=0
 off=57 message complete
 ```
@@ -167,10 +177,15 @@ Proxy-authorization: basic aGVsbG86d29ybGQ=
 ```log
 off=0 message begin
 off=8 len=23 span[url]="home_0.netscape.com:443"
+off=32 url complete
 off=42 len=10 span[header_field]="User-agent"
+off=53 header_field complete
 off=54 len=12 span[header_value]="Mozilla/1.1N"
+off=68 header_value complete
 off=68 len=19 span[header_field]="Proxy-authorization"
+off=88 header_field complete
 off=89 len=22 span[header_value]="basic aGVsbG86d29ybGQ="
+off=113 header_value complete
 off=115 headers complete method=5 v=1/0 flags=0 content_length=0
 off=115 message complete
 off=115 error code=22 reason="Pause on CONNECT/Upgrade"
@@ -188,6 +203,7 @@ GET http://a%12:b!&*$@hypnotoad.org:1234/toto HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=41 span[url]="http://a%12:b!&*$@hypnotoad.org:1234/toto"
+off=46 url complete
 off=58 headers complete method=1 v=1/1 flags=0 content_length=0
 off=58 message complete
 ```
@@ -204,5 +220,6 @@ GET /foo bar/ HTTP/1.1
 ```log
 off=0 message begin
 off=4 len=4 span[url]="/foo"
+off=9 url complete
 off=9 error code=8 reason="Expected HTTP/"
 ```

--- a/test/response/connection.md
+++ b/test/response/connection.md
@@ -17,14 +17,23 @@ hello world
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=12 span[header_field]="Content-Type"
+off=30 header_field complete
 off=31 len=24 span[header_value]="text/html; charset=UTF-8"
+off=57 header_value complete
 off=57 len=14 span[header_field]="Content-Length"
+off=72 header_field complete
 off=73 len=2 span[header_value]="11"
+off=77 header_value complete
 off=77 len=16 span[header_field]="Proxy-Connection"
+off=94 header_field complete
 off=95 len=5 span[header_value]="close"
+off=102 header_value complete
 off=102 len=4 span[header_field]="Date"
+off=107 header_field complete
 off=108 len=31 span[header_value]="Thu, 31 Dec 2009 20:55:48 +0000"
+off=141 header_value complete
 off=143 headers complete status=200 v=1/1 flags=22 content_length=11
 off=143 len=11 span[body]="hello world"
 off=154 message complete
@@ -46,8 +55,11 @@ HTTP/1.0 200 OK
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=10 span[header_field]="Connection"
+off=28 header_field complete
 off=29 len=10 span[header_value]="keep-alive"
+off=41 header_value complete
 off=43 headers complete status=200 v=1/0 flags=1 content_length=0
 off=43 len=15 span[body]="HTTP/1.0 200 OK"
 ```
@@ -67,8 +79,11 @@ HTTP/1.0 200 OK
 ```log
 off=0 message begin
 off=13 len=10 span[status]="No content"
+off=25 status complete
 off=25 len=10 span[header_field]="Connection"
+off=36 header_field complete
 off=37 len=10 span[header_value]="keep-alive"
+off=49 header_value complete
 off=51 headers complete status=204 v=1/0 flags=1 content_length=0
 off=51 message complete
 off=51 message begin
@@ -90,6 +105,7 @@ HTTP/1.1 200 OK
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=19 headers complete status=200 v=1/1 flags=0 content_length=0
 off=19 len=15 span[body]="HTTP/1.1 200 OK"
 ```
@@ -108,6 +124,7 @@ HTTP/1.1 200 OK
 ```log
 off=0 message begin
 off=13 len=10 span[status]="No content"
+off=25 status complete
 off=27 headers complete status=204 v=1/1 flags=0 content_length=0
 off=27 message complete
 off=27 message begin
@@ -127,8 +144,11 @@ HTTP/1.1 200 OK
 ```log
 off=0 message begin
 off=13 len=10 span[status]="No content"
+off=25 status complete
 off=25 len=10 span[header_field]="Connection"
+off=36 header_field complete
 off=37 len=5 span[header_value]="close"
+off=44 header_value complete
 off=46 headers complete status=204 v=1/1 flags=2 content_length=0
 off=46 message complete
 off=47 error code=5 reason="Data after `Connection: close`"
@@ -147,8 +167,11 @@ HTTP/1.1 200 OK
 ```log
 off=0 message begin
 off=13 len=10 span[status]="No content"
+off=25 status complete
 off=25 len=10 span[header_field]="Connection"
+off=36 header_field complete
 off=37 len=5 span[header_value]="close"
+off=44 header_value complete
 off=46 headers complete status=204 v=1/1 flags=2 content_length=0
 off=46 message complete
 off=46 message begin
@@ -171,12 +194,19 @@ proto
 ```log
 off=0 message begin
 off=13 len=19 span[status]="Switching Protocols"
+off=34 status complete
 off=34 len=10 span[header_field]="Connection"
+off=45 header_field complete
 off=46 len=7 span[header_value]="upgrade"
+off=55 header_value complete
 off=55 len=7 span[header_field]="Upgrade"
+off=63 header_field complete
 off=64 len=3 span[header_value]="h2c"
+off=69 header_value complete
 off=69 len=14 span[header_field]="Content-Length"
+off=84 header_field complete
 off=85 len=1 span[header_value]="4"
+off=88 header_value complete
 off=90 headers complete status=101 v=1/1 flags=34 content_length=4
 off=90 len=4 span[body]="body"
 off=94 message complete
@@ -204,12 +234,19 @@ proto
 ```log
 off=0 message begin
 off=13 len=19 span[status]="Switching Protocols"
+off=34 status complete
 off=34 len=10 span[header_field]="Connection"
+off=45 header_field complete
 off=46 len=7 span[header_value]="upgrade"
+off=55 header_value complete
 off=55 len=7 span[header_field]="Upgrade"
+off=63 header_field complete
 off=64 len=3 span[header_value]="h2c"
+off=69 header_value complete
 off=69 len=17 span[header_field]="Transfer-Encoding"
+off=87 header_field complete
 off=88 len=7 span[header_value]="chunked"
+off=97 header_value complete
 off=99 headers complete status=101 v=1/1 flags=21c content_length=0
 off=102 chunk header len=2
 off=102 len=2 span[body]="bo"
@@ -237,10 +274,15 @@ body
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=10 span[header_field]="Connection"
+off=28 header_field complete
 off=29 len=7 span[header_value]="upgrade"
+off=38 header_value complete
 off=38 len=7 span[header_field]="Upgrade"
+off=46 header_field complete
 off=47 len=3 span[header_value]="h2c"
+off=52 header_value complete
 off=54 headers complete status=200 v=1/1 flags=14 content_length=0
 off=54 len=4 span[body]="body"
 ```
@@ -260,12 +302,19 @@ body
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=10 span[header_field]="Connection"
+off=28 header_field complete
 off=29 len=7 span[header_value]="upgrade"
+off=38 header_value complete
 off=38 len=7 span[header_field]="Upgrade"
+off=46 header_field complete
 off=47 len=3 span[header_value]="h2c"
+off=52 header_value complete
 off=52 len=14 span[header_field]="Content-Length"
+off=67 header_field complete
 off=68 len=1 span[header_value]="4"
+off=71 header_value complete
 off=73 headers complete status=200 v=1/1 flags=34 content_length=4
 off=73 len=4 span[body]="body"
 off=77 message complete
@@ -292,12 +341,19 @@ dy
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=10 span[header_field]="Connection"
+off=28 header_field complete
 off=29 len=7 span[header_value]="upgrade"
+off=38 header_value complete
 off=38 len=7 span[header_field]="Upgrade"
+off=46 header_field complete
 off=47 len=3 span[header_value]="h2c"
+off=52 header_value complete
 off=52 len=17 span[header_field]="Transfer-Encoding"
+off=70 header_field complete
 off=71 len=7 span[header_value]="chunked"
+off=80 header_value complete
 off=82 headers complete status=200 v=1/1 flags=21c content_length=0
 off=85 chunk header len=2
 off=85 len=2 span[body]="bo"

--- a/test/response/content-length.md
+++ b/test/response/content-length.md
@@ -32,16 +32,27 @@ Connection: close
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=4 span[header_field]="Date"
+off=22 header_field complete
 off=23 len=29 span[header_value]="Tue, 04 Aug 2009 07:59:32 GMT"
+off=54 header_value complete
 off=54 len=6 span[header_field]="Server"
+off=61 header_field complete
 off=62 len=6 span[header_value]="Apache"
+off=70 header_value complete
 off=70 len=12 span[header_field]="X-Powered-By"
+off=83 header_field complete
 off=84 len=19 span[header_value]="Servlet/2.5 JSP/2.1"
+off=105 header_value complete
 off=105 len=12 span[header_field]="Content-Type"
+off=118 header_field complete
 off=119 len=23 span[header_value]="text/xml; charset=utf-8"
+off=144 header_value complete
 off=144 len=10 span[header_field]="Connection"
+off=155 header_field complete
 off=156 len=5 span[header_value]="close"
+off=163 header_value complete
 off=165 headers complete status=200 v=1/1 flags=2 content_length=0
 off=165 len=42 span[body]="<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
 off=207 len=1 span[body]=lf
@@ -83,10 +94,15 @@ OK
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=16 span[header_field]="Content-Length-X"
+off=34 header_field complete
 off=35 len=1 span[header_value]="0"
+off=38 header_value complete
 off=38 len=17 span[header_field]="Transfer-Encoding"
+off=56 header_field complete
 off=57 len=7 span[header_value]="chunked"
+off=66 header_value complete
 off=68 headers complete status=200 v=1/1 flags=208 content_length=0
 off=71 chunk header len=2
 off=71 len=2 span[body]="OK"

--- a/test/response/finish.md
+++ b/test/response/finish.md
@@ -15,6 +15,7 @@ HTTP/1.1 200 OK
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=19 headers complete status=200 v=1/1 flags=0 content_length=0
 off=NULL finish=1
 ```

--- a/test/response/invalid.md
+++ b/test/response/invalid.md
@@ -100,7 +100,9 @@ Foo: 1\rBar: 2
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=3 span[header_field]="Foo"
+off=21 header_field complete
 off=22 len=1 span[header_value]="1"
 off=24 error code=3 reason="Missing expected LF after header value"
 ```

--- a/test/response/sample.md
+++ b/test/response/sample.md
@@ -16,12 +16,19 @@ Content-Length: 0
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=7 span[header_field]="Header1"
+off=25 header_field complete
 off=26 len=6 span[header_value]="Value1"
+off=34 header_value complete
 off=34 len=7 span[header_field]="Header2"
+off=42 header_field complete
 off=44 len=6 span[header_value]="Value2"
+off=52 header_value complete
 off=52 len=14 span[header_field]="Content-Length"
+off=67 header_field complete
 off=68 len=1 span[header_value]="0"
+off=71 header_value complete
 off=73 headers complete status=200 v=1/1 flags=20 content_length=0
 off=73 message complete
 ```
@@ -54,6 +61,7 @@ HTTP/1.1 200 OK
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=19 headers complete status=200 v=1/1 flags=0 content_length=0
 ```
 
@@ -83,22 +91,39 @@ _(Note the `$` char in header field)_
 ```log
 off=0 message begin
 off=13 len=17 span[status]="Moved Permanently"
+off=32 status complete
 off=32 len=8 span[header_field]="Location"
+off=41 header_field complete
 off=42 len=22 span[header_value]="http://www.google.com/"
+off=66 header_value complete
 off=66 len=12 span[header_field]="Content-Type"
+off=79 header_field complete
 off=80 len=24 span[header_value]="text/html; charset=UTF-8"
+off=106 header_value complete
 off=106 len=4 span[header_field]="Date"
+off=111 header_field complete
 off=112 len=29 span[header_value]="Sun, 26 Apr 2009 11:11:49 GMT"
+off=143 header_value complete
 off=143 len=7 span[header_field]="Expires"
+off=151 header_field complete
 off=152 len=29 span[header_value]="Tue, 26 May 2009 11:11:49 GMT"
+off=183 header_value complete
 off=183 len=22 span[header_field]="X-$PrototypeBI-Version"
+off=206 header_field complete
 off=207 len=7 span[header_value]="1.6.0.3"
+off=216 header_value complete
 off=216 len=13 span[header_field]="Cache-Control"
+off=230 header_field complete
 off=231 len=23 span[header_value]="public, max-age=2592000"
+off=256 header_value complete
 off=256 len=6 span[header_field]="Server"
+off=263 header_field complete
 off=264 len=3 span[header_value]="gws"
+off=269 header_value complete
 off=269 len=14 span[header_field]="Content-Length"
+off=284 header_field complete
 off=286 len=5 span[header_value]="219  "
+off=293 header_value complete
 off=295 headers complete status=301 v=1/1 flags=20 content_length=219
 off=295 len=74 span[body]="<HTML><HEAD><meta http-equiv=content-type content=text/html;charset=utf-8>"
 off=369 len=1 span[body]=lf
@@ -139,24 +164,43 @@ Transfer-Encoding: chunked
 ```log
 off=0 message begin
 off=13 len=16 span[status]="MovedPermanently"
+off=31 status complete
 off=31 len=4 span[header_field]="Date"
+off=36 header_field complete
 off=37 len=29 span[header_value]="Wed, 15 May 2013 17:06:33 GMT"
+off=68 header_value complete
 off=68 len=6 span[header_field]="Server"
+off=75 header_field complete
 off=76 len=6 span[header_value]="Server"
+off=84 header_value complete
 off=84 len=10 span[header_field]="x-amz-id-1"
+off=95 header_field complete
 off=96 len=20 span[header_value]="0GPHKXSJQ826RK7GZEB2"
+off=118 header_value complete
 off=118 len=3 span[header_field]="p3p"
+off=122 header_field complete
 off=123 len=178 span[header_value]="policyref="http://www.amazon.com/w3c/p3p.xml",CP="CAO DSP LAW CUR ADM IVAo IVDo CONo OTPo OUR DELi PUBi OTRi BUS PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA HEA PRE LOC GOV OTC ""
+off=303 header_value complete
 off=303 len=10 span[header_field]="x-amz-id-2"
+off=314 header_field complete
 off=315 len=64 span[header_value]="STN69VZxIFSz9YJLbz1GDbxpbjG6Qjmmq5E3DxRhOUw+Et0p4hr7c/Q8qNcx4oAD"
+off=381 header_value complete
 off=381 len=8 span[header_field]="Location"
+off=390 header_field complete
 off=391 len=214 span[header_value]="http://www.amazon.com/Dan-Brown/e/B000AP9DSU/ref=s9_pop_gw_al1?_encoding=UTF8&refinementId=618073011&pf_rd_m=ATVPDKIKX0DER&pf_rd_s=center-2&pf_rd_r=0SHYY5BZXN3KR20BNFAY&pf_rd_t=101&pf_rd_p=1263340922&pf_rd_i=507846"
+off=607 header_value complete
 off=607 len=4 span[header_field]="Vary"
+off=612 header_field complete
 off=613 len=26 span[header_value]="Accept-Encoding,User-Agent"
+off=641 header_value complete
 off=641 len=12 span[header_field]="Content-Type"
+off=654 header_field complete
 off=655 len=29 span[header_value]="text/html; charset=ISO-8859-1"
+off=686 header_value complete
 off=686 len=17 span[header_field]="Transfer-Encoding"
+off=704 header_field complete
 off=705 len=7 span[header_value]="chunked"
+off=714 header_value complete
 off=716 headers complete status=301 v=1/1 flags=208 content_length=0
 off=719 chunk header len=1
 off=719 len=1 span[body]=lf
@@ -178,6 +222,7 @@ HTTP/1.1 404 Not Found
 ```log
 off=0 message begin
 off=13 len=9 span[status]="Not Found"
+off=24 status complete
 off=26 headers complete status=404 v=1/1 flags=0 content_length=0
 ```
 
@@ -192,6 +237,7 @@ HTTP/1.1 301
 
 ```log
 off=0 message begin
+off=14 status complete
 off=16 headers complete status=301 v=1/1 flags=0 content_length=0
 ```
 
@@ -206,6 +252,7 @@ HTTP/1.1 200 \r\n\
 
 ```log
 off=0 message begin
+off=15 status complete
 off=17 headers complete status=200 v=1/1 flags=0 content_length=0
 ```
 
@@ -223,10 +270,15 @@ these headers are from http://news.ycombinator.com/
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=16 status complete
 off=16 len=12 span[header_field]="Content-Type"
+off=29 header_field complete
 off=30 len=24 span[header_value]="text/html; charset=utf-8"
+off=55 header_value complete
 off=55 len=10 span[header_field]="Connection"
+off=66 header_field complete
 off=67 len=5 span[header_value]="close"
+off=73 header_value complete
 off=74 headers complete status=200 v=1/1 flags=2 content_length=0
 off=74 len=51 span[body]="these headers are from http://news.ycombinator.com/"
 ```
@@ -249,14 +301,23 @@ DCLK_imp: v7;x;114750856;0-0;0;17820020;0/0;21603567/21621457/1;;~okv=;dcmt=text
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=6 span[header_field]="Server"
+off=24 header_field complete
 off=25 len=10 span[header_value]="DCLK-AdSvr"
+off=37 header_value complete
 off=37 len=12 span[header_field]="Content-Type"
+off=50 header_field complete
 off=51 len=8 span[header_value]="text/xml"
+off=61 header_value complete
 off=61 len=14 span[header_field]="Content-Length"
+off=76 header_field complete
 off=77 len=1 span[header_value]="0"
+off=80 header_value complete
 off=80 len=8 span[header_field]="DCLK_imp"
+off=89 header_field complete
 off=90 len=81 span[header_value]="v7;x;114750856;0-0;0;17820020;0/0;21603567/21621457/1;;~okv=;dcmt=text/xml;;~cs=o"
+off=173 header_value complete
 off=175 headers complete status=200 v=1/1 flags=20 content_length=0
 off=175 message complete
 ```
@@ -285,24 +346,43 @@ Connection: keep-alive
 ```log
 off=0 message begin
 off=13 len=17 span[status]="Moved Permanently"
+off=32 status complete
 off=32 len=4 span[header_field]="Date"
+off=37 header_field complete
 off=38 len=29 span[header_value]="Thu, 03 Jun 2010 09:56:32 GMT"
+off=69 header_value complete
 off=69 len=6 span[header_field]="Server"
+off=76 header_field complete
 off=77 len=22 span[header_value]="Apache/2.2.3 (Red Hat)"
+off=101 header_value complete
 off=101 len=13 span[header_field]="Cache-Control"
+off=115 header_field complete
 off=116 len=6 span[header_value]="public"
+off=124 header_value complete
 off=124 len=6 span[header_field]="Pragma"
+off=131 header_field complete
 off=134 len=0 span[header_value]=""
+off=134 header_value complete
 off=134 len=8 span[header_field]="Location"
+off=143 header_field complete
 off=144 len=28 span[header_value]="http://www.bonjourmadame.fr/"
+off=174 header_value complete
 off=174 len=4 span[header_field]="Vary"
+off=179 header_field complete
 off=180 len=15 span[header_value]="Accept-Encoding"
+off=197 header_value complete
 off=197 len=14 span[header_field]="Content-Length"
+off=212 header_field complete
 off=213 len=1 span[header_value]="0"
+off=216 header_value complete
 off=216 len=12 span[header_field]="Content-Type"
+off=229 header_field complete
 off=230 len=24 span[header_value]="text/html; charset=UTF-8"
+off=256 header_value complete
 off=256 len=10 span[header_field]="Connection"
+off=267 header_field complete
 off=268 len=10 span[header_value]="keep-alive"
+off=280 header_value complete
 off=282 headers complete status=301 v=1/0 flags=21 content_length=0
 off=282 message complete
 ```
@@ -332,28 +412,51 @@ Connection: close
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=4 span[header_field]="Date"
+off=22 header_field complete
 off=23 len=29 span[header_value]="Tue, 28 Sep 2010 01:14:13 GMT"
+off=54 header_value complete
 off=54 len=6 span[header_field]="Server"
+off=61 header_field complete
 off=62 len=6 span[header_value]="Apache"
+off=70 header_value complete
 off=70 len=13 span[header_field]="Cache-Control"
+off=84 header_field complete
 off=85 len=25 span[header_value]="no-cache, must-revalidate"
+off=112 header_value complete
 off=112 len=7 span[header_field]="Expires"
+off=120 header_field complete
 off=121 len=29 span[header_value]="Mon, 26 Jul 1997 05:00:00 GMT"
+off=152 header_value complete
 off=152 len=10 span[header_field]=".et-Cookie"
+off=163 header_field complete
 off=164 len=54 span[header_value]="PlaxoCS=1274804622353690521; path=/; domain=.plaxo.com"
+off=220 header_value complete
 off=220 len=4 span[header_field]="Vary"
+off=225 header_field complete
 off=226 len=15 span[header_value]="Accept-Encoding"
+off=243 header_value complete
 off=243 len=10 span[header_field]="_eep-Alive"
+off=254 header_field complete
 off=255 len=10 span[header_value]="timeout=45"
+off=267 header_value complete
 off=267 len=10 span[header_field]="_onnection"
+off=278 header_field complete
 off=279 len=10 span[header_value]="Keep-Alive"
+off=291 header_value complete
 off=291 len=17 span[header_field]="Transfer-Encoding"
+off=309 header_field complete
 off=310 len=7 span[header_value]="chunked"
+off=319 header_value complete
 off=319 len=12 span[header_field]="Content-Type"
+off=332 header_field complete
 off=333 len=9 span[header_value]="text/html"
+off=344 header_value complete
 off=344 len=10 span[header_field]="Connection"
+off=355 header_field complete
 off=356 len=5 span[header_value]="close"
+off=363 header_value complete
 off=365 headers complete status=200 v=1/1 flags=20a content_length=0
 off=368 chunk header len=0
 off=370 chunk complete
@@ -379,10 +482,15 @@ Connection: keep-alive
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=6 span[header_field]="Server"
+off=24 header_field complete
 off=25 len=17 span[header_value]="Microsoft-IIS/6.0"
+off=44 header_value complete
 off=44 len=12 span[header_field]="X-Powered-By"
+off=57 header_field complete
 off=58 len=7 span[header_value]="ASP.NET"
+off=67 header_value complete
 off=72 error code=10 reason="Invalid header token"
 ```
 
@@ -407,20 +515,35 @@ Connection: keep-alive
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=6 span[header_field]="Server"
+off=24 header_field complete
 off=25 len=17 span[header_value]="Microsoft-IIS/6.0"
+off=44 header_value complete
 off=44 len=12 span[header_field]="X-Powered-By"
+off=57 header_field complete
 off=58 len=7 span[header_value]="ASP.NET"
+off=67 header_value complete
 off=67 len=18 span[header_field]="en-US Content-Type"
+off=86 header_field complete
 off=87 len=8 span[header_value]="text/xml"
+off=97 header_value complete
 off=97 len=12 span[header_field]="Content-Type"
+off=110 header_field complete
 off=111 len=8 span[header_value]="text/xml"
+off=121 header_value complete
 off=121 len=14 span[header_field]="Content-Length"
+off=136 header_field complete
 off=137 len=2 span[header_value]="16"
+off=141 header_value complete
 off=141 len=4 span[header_field]="Date"
+off=146 header_field complete
 off=147 len=29 span[header_value]="Fri, 23 Jul 2010 18:45:38 GMT"
+off=178 header_value complete
 off=178 len=10 span[header_field]="Connection"
+off=189 header_field complete
 off=190 len=10 span[header_value]="keep-alive"
+off=202 header_value complete
 off=204 headers complete status=200 v=1/1 flags=21 content_length=16
 off=204 len=16 span[body]="<xml>hello</xml>"
 off=220 message complete
@@ -441,12 +564,19 @@ Connection: close
 ```log
 off=0 message begin
 off=13 len=19 span[status]="Oriëntatieprobleem"
+off=34 status complete
 off=34 len=4 span[header_field]="Date"
+off=39 header_field complete
 off=40 len=30 span[header_value]="Fri, 5 Nov 2010 23:07:12 GMT+2"
+off=72 header_value complete
 off=72 len=14 span[header_field]="Content-Length"
+off=87 header_field complete
 off=88 len=1 span[header_value]="0"
+off=91 header_value complete
 off=91 len=10 span[header_field]="Connection"
+off=102 header_field complete
 off=103 len=5 span[header_value]="close"
+off=110 header_value complete
 off=112 headers complete status=500 v=1/1 flags=22 content_length=0
 off=112 message complete
 ```
@@ -463,6 +593,7 @@ HTTP/0.9 200 OK
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=19 headers complete status=200 v=0/9 flags=0 content_length=0
 ```
 
@@ -483,8 +614,11 @@ hello world
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=12 span[header_field]="Content-Type"
+off=30 header_field complete
 off=31 len=10 span[header_value]="text/plain"
+off=43 header_value complete
 off=45 headers complete status=200 v=1/1 flags=0 content_length=0
 off=45 len=11 span[body]="hello world"
 ```
@@ -504,12 +638,19 @@ Content-Length: 0
 ```log
 off=2 message begin
 off=15 len=2 span[status]="OK"
+off=19 status complete
 off=19 len=7 span[header_field]="Header1"
+off=27 header_field complete
 off=28 len=6 span[header_value]="Value1"
+off=36 header_value complete
 off=36 len=7 span[header_field]="Header2"
+off=44 header_field complete
 off=46 len=6 span[header_value]="Value2"
+off=54 header_value complete
 off=54 len=14 span[header_field]="Content-Length"
+off=69 header_field complete
 off=70 len=1 span[header_value]="0"
+off=73 header_value complete
 off=75 headers complete status=200 v=1/1 flags=20 content_length=0
 off=75 message complete
 ```

--- a/test/response/transfer-encoding.md
+++ b/test/response/transfer-encoding.md
@@ -23,10 +23,15 @@ and this is the second one
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=12 span[header_field]="Content-Type"
+off=30 header_field complete
 off=31 len=10 span[header_value]="text/plain"
+off=43 header_value complete
 off=43 len=17 span[header_field]="Transfer-Encoding"
+off=61 header_field complete
 off=62 len=7 span[header_value]="chunked"
+off=71 header_value complete
 off=73 headers complete status=200 v=1/1 flags=208 content_length=0
 off=79 chunk header len=37
 off=79 len=35 span[body]="This is the data in the first chunk"
@@ -57,10 +62,15 @@ World
 ```log
 off=0 message begin
 off=13 len=2 span[status]="OK"
+off=17 status complete
 off=17 len=6 span[header_field]="Accept"
+off=24 header_field complete
 off=25 len=3 span[header_value]="*/*"
+off=30 header_value complete
 off=30 len=17 span[header_field]="Transfer-Encoding"
+off=48 header_field complete
 off=49 len=16 span[header_value]="chunked, deflate"
+off=67 header_value complete
 off=69 headers complete status=200 v=1/1 flags=200 content_length=0
 off=69 len=5 span[body]="World"
 ```


### PR DESCRIPTION
In 4cc13c0, the `on_header_field_complete` callback was added.  However,
special header fields take a different path out than general header fields,
so this callback would not be called for them.  This change hooks that path
up to the callback.  In general, any call to `span.headerField.end()` should
be followed by `onHeaderFieldComplete`.

I preëmptively checked to make sure that there was not a similar mistake in
`on_header_value_complete` and there was, specifically for any field except
Content-Length with a completely empty value.  Empty Content-Length is an
error, and the path that checks this was not hooked up.  Now it is too.  In
general, the header value states should never directly transition back to
`header_field_start`, they should poke `onHeaderValueComplete`.

Issue: nodejs/llhttp#79