### PR TITLE
api: add llhttp_reset

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -24,6 +24,21 @@ void llhttp_init(llhttp_t* parser, llhttp_type_t type,
 }
 
 
+void llhttp_reset(llhttp_t* parser) {
+  llhttp_type_t type = parser->type;
+  const llhttp_settings_t* settings = parser->settings;
+  void* data = parser->data;
+  uint8_t lenient_flags = parser->lenient_flags;
+
+  llhttp__internal_init(parser);
+
+  parser->type = type;
+  parser->settings = (void*) settings;
+  parser->data = data;
+  parser->lenient_flags = lenient_flags;
+}
+
+
 llhttp_errno_t llhttp_execute(llhttp_t* parser, const char* data, size_t len) {
   return llhttp__internal_execute(parser, data, data + len);
 }

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -6,8 +6,8 @@
 
 #define CALLBACK_MAYBE(PARSER, NAME, ...)                                     \
   do {                                                                        \
-    llhttp_settings_t* settings;                                              \
-    settings = (llhttp_settings_t*) (PARSER)->settings;                       \
+    const llhttp_settings_t* settings;                                        \
+    settings = (const llhttp_settings_t*) (PARSER)->settings;                 \
     if (settings == NULL || settings->NAME == NULL) {                         \
       err = 0;                                                                \
       break;                                                                  \

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -58,6 +58,11 @@ struct llhttp_settings_s {
 void llhttp_init(llhttp_t* parser, llhttp_type_t type,
                  const llhttp_settings_t* settings);
 
+/* Reset an already initialized parser back to the start state, preserving the
+ * existing parser type, callback settings, user data, and lenient flags.
+ */
+void llhttp_reset(llhttp_t* parser);
+
 /* Initialize the settings object */
 void llhttp_settings_init(llhttp_settings_t* settings);
 


### PR DESCRIPTION
This change adds a helper method that resets the state of an existing, already initialized parser, preserving the type, settings, user data, and flags.  This is useful for wrappers that want to reset the internal parser state without having to manually save and restore the configuration state.