### PR TITLE
http: PRI upgrade should return PAUSED_H2_UPGRADE

### DIFF
--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -30,6 +30,7 @@ export enum ERROR {
 
   PAUSED,
   PAUSED_UPGRADE,
+  PAUSED_H2_UPGRADE,
 
   USER,
 }

--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -375,8 +375,10 @@ export class HTTP {
       .otherwise(p.error(ERROR.INVALID_VERSION, 'Expected CRLF after version'));
 
     n('req_pri_upgrade')
-      .match('\r\n\r\nSM\r\n\r\n', p.error(ERROR.PAUSED_UPGRADE, 'Pause on PRI/Upgrade'))
-      .otherwise(p.error(ERROR.INVALID_VERSION, 'Expected HTTP/2 Connection Preface'));
+      .match('\r\n\r\nSM\r\n\r\n',
+        p.error(ERROR.PAUSED_H2_UPGRADE, 'Pause on PRI/Upgrade'))
+      .otherwise(
+        p.error(ERROR.INVALID_VERSION, 'Expected HTTP/2 Connection Preface'));
   }
 
   private buildHeaders(): void {

--- a/test/request/method.md
+++ b/test/request/method.md
@@ -386,5 +386,5 @@ SM
 off=0 message begin
 off=4 len=1 span[url]="*"
 off=6 url complete
-off=24 error code=22 reason="Pause on PRI/Upgrade"
+off=24 error code=23 reason="Pause on PRI/Upgrade"
 ```


### PR DESCRIPTION
`PAUSED_UPGRADE` is a recoverable error and should not be returned when
parsing HTTP/2 `PRI /...` preambule, which is the last message that can
be parsed on the stream.

---

@pallas could you give this a quick review when you'll get a chance? I've tried updating llhttp in Node.js and quickly ran into this issue. Basically, our documentation says that `llhttp_resume_after_upgrade` should be called after `PAUSED_UPGRADE`, and it resets the `.error` to `0`, but in reality the parser is in non-recoverable state! This is a breaking change, but I'm going to treat it as a bugfix and do a minor release for all branches once landed.

cc @nodejs/http @nodejs/http2  as well