### PR TITLE
readme: add a link to api.h for better guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ if (err == HPE_OK) {
           parser.reason);
 }
 ```
+For more information on API usage, please refer to https://github.com/nodejs/llhttp/blob/master/src/native/api.h
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ if (err == HPE_OK) {
           parser.reason);
 }
 ```
-For more information on API usage, please refer to https://github.com/nodejs/llhttp/blob/master/src/native/api.h
+For more information on API usage, please refer to [src/native/api.h](https://github.com/nodejs/llhttp/blob/master/src/native/api.h).
 
 ---
 


### PR DESCRIPTION
## Description

Sorry if this sounds silly to you, but when I first tried out this project, I thought I have to look back on [http_parser][] in order to find out what callback functions could I use. Not until I saw you mention in [this issue][issue] did I realize that they were already thoroughly documented in [api.h][]. Therefore, I think it would be beneficial if we include this single line in README.md.

Another silly thought: I'm afraid that some developers are not familiar to building a node project. Therefore, it would be nice if there is a _build instruction_ within README.md, since a simple `make` won't work.


[http_parser]: https://github.com/nodejs/http-parser
[issue]: https://github.com/nodejs/llhttp/issues/98
[api.h]: https://github.com/nodejs/llhttp/blob/master/src/native/api.h