### PR TITLE
api: limit `HTTP_METHOD_MAP` to HTTP methods

### DIFF
--- a/src/llhttp/c-headers.ts
+++ b/src/llhttp/c-headers.ts
@@ -18,6 +18,8 @@ export class CHeaders {
 
     const errorMap = enumToMap(constants.ERROR);
     const methodMap = enumToMap(constants.METHODS);
+    const httpMethodMap = enumToMap(constants.METHODS, constants.METHODS_HTTP);
+    const rtspMethodMap = enumToMap(constants.METHODS, constants.METHODS_RTSP);
 
     res += this.buildEnum('llhttp_errno', 'HPE', errorMap);
     res += '\n';
@@ -39,8 +41,11 @@ export class CHeaders {
 
     res += this.buildMap('HTTP_ERRNO', errorMap);
     res += '\n';
-    res += this.buildMap('HTTP_METHOD', methodMap);
+    res += this.buildMap('HTTP_METHOD', httpMethodMap);
     res += '\n';
+    res += this.buildMap('RTSP_METHOD', rtspMethodMap);
+    res += '\n';
+    res += this.buildMap('HTTP_ALL_METHOD', methodMap);
 
     res += '\n';
 

--- a/src/llhttp/utils.ts
+++ b/src/llhttp/utils.ts
@@ -2,14 +2,18 @@ export interface IEnumMap {
   [key: string]: number;
 }
 
-export function enumToMap(obj: any): IEnumMap {
+export function enumToMap(obj: any, filter?: ReadonlyArray<number>): IEnumMap {
   const res: IEnumMap = {};
 
   Object.keys(obj).forEach((key) => {
     const value = obj[key];
-    if (typeof value === 'number') {
-      res[key] = value;
+    if (typeof value !== 'number') {
+      return;
     }
+    if (filter && !filter.includes(value)) {
+      return;
+    }
+    res[key] = value;
   });
 
   return res;

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -199,7 +199,7 @@ const char* llhttp_errno_name(llhttp_errno_t err) {
 const char* llhttp_method_name(llhttp_method_t method) {
 #define HTTP_METHOD_GEN(NUM, NAME, STRING) case HTTP_##NAME: return #STRING;
   switch (method) {
-    HTTP_METHOD_MAP(HTTP_METHOD_GEN)
+    HTTP_ALL_METHOD_MAP(HTTP_METHOD_GEN)
     default: abort();
   }
 #undef HTTP_METHOD_GEN


### PR DESCRIPTION
RTSP methods shouldn't mix up with HTTP methods in the method map since
they are supported only with the RTSP protocol. Node.js uses
`HTTP_METHOD_MAP` to generate `http.METHODS` array and this breaks tests
in `body-parser` because it assumes that all of these methods are for
HTTP requests.

cc @nodejs/http 