### PR TITLE
api: allow returning -1 in spans, doc HPE_USER

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -4,7 +4,7 @@
 
 #include "llhttp.h"
 
-#define CALLBACK_MAYBE(PARSER, NAME, ...)                                     \
+#define CALLBACK_MAYBE(PARSER, NAME)                                          \
   do {                                                                        \
     const llhttp_settings_t* settings;                                        \
     settings = (const llhttp_settings_t*) (PARSER)->settings;                 \
@@ -12,7 +12,22 @@
       err = 0;                                                                \
       break;                                                                  \
     }                                                                         \
-    err = settings->NAME(__VA_ARGS__);                                        \
+    err = settings->NAME((PARSER));                                           \
+  } while (0)
+
+#define SPAN_CALLBACK_MAYBE(PARSER, NAME, START, LEN)                         \
+  do {                                                                        \
+    const llhttp_settings_t* settings;                                        \
+    settings = (const llhttp_settings_t*) (PARSER)->settings;                 \
+    if (settings == NULL || settings->NAME == NULL) {                         \
+      err = 0;                                                                \
+      break;                                                                  \
+    }                                                                         \
+    err = settings->NAME((PARSER), (START), (LEN));                           \
+    if (err == -1) {                                                          \
+      err = HPE_USER;                                                         \
+      llhttp_set_error_reason((PARSER), "Span callback error in " #NAME);     \
+    }                                                                         \
   } while (0)
 
 void llhttp_init(llhttp_t* parser, llhttp_type_t type,
@@ -123,7 +138,7 @@ llhttp_errno_t llhttp_finish(llhttp_t* parser) {
 
   switch (parser->finish) {
     case HTTP_FINISH_SAFE_WITH_CB:
-      CALLBACK_MAYBE(parser, on_message_complete, parser);
+      CALLBACK_MAYBE(parser, on_message_complete);
       if (err != HPE_OK) return err;
 
     /* FALLTHROUGH */
@@ -237,98 +252,98 @@ void llhttp_set_lenient_keep_alive(llhttp_t* parser, int enabled) {
 
 int llhttp__on_message_begin(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_message_begin, s);
+  CALLBACK_MAYBE(s, on_message_begin);
   return err;
 }
 
 
 int llhttp__on_url(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_url, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_url, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_url_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_url_complete, s);
+  CALLBACK_MAYBE(s, on_url_complete);
   return err;
 }
 
 
 int llhttp__on_status(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_status, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_status, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_status_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_status_complete, s);
+  CALLBACK_MAYBE(s, on_status_complete);
   return err;
 }
 
 
 int llhttp__on_header_field(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_header_field, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_header_field, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_header_field_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_header_field_complete, s);
+  CALLBACK_MAYBE(s, on_header_field_complete);
   return err;
 }
 
 
 int llhttp__on_header_value(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_header_value, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_header_value, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_header_value_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_header_value_complete, s);
+  CALLBACK_MAYBE(s, on_header_value_complete);
   return err;
 }
 
 
 int llhttp__on_headers_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_headers_complete, s);
+  CALLBACK_MAYBE(s, on_headers_complete);
   return err;
 }
 
 
 int llhttp__on_message_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_message_complete, s);
+  CALLBACK_MAYBE(s, on_message_complete);
   return err;
 }
 
 
 int llhttp__on_body(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_body, s, p, endp - p);
+  SPAN_CALLBACK_MAYBE(s, on_body, p, endp - p);
   return err;
 }
 
 
 int llhttp__on_chunk_header(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_chunk_header, s);
+  CALLBACK_MAYBE(s, on_chunk_header);
   return err;
 }
 
 
 int llhttp__on_chunk_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
-  CALLBACK_MAYBE(s, on_chunk_complete, s);
+  CALLBACK_MAYBE(s, on_chunk_complete);
   return err;
 }
 

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -21,6 +21,7 @@ struct llhttp_settings_s {
   /* Possible return values 0, -1, `HPE_PAUSED` */
   llhttp_cb      on_message_begin;
 
+  /* Possible return values 0, -1, HPE_USER */
   llhttp_data_cb on_url;
   llhttp_data_cb on_status;
   llhttp_data_cb on_header_field;
@@ -37,6 +38,7 @@ struct llhttp_settings_s {
    */
   llhttp_cb      on_headers_complete;
 
+  /* Possible return values 0, -1, HPE_USER */
   llhttp_data_cb on_body;
 
   /* Possible return values 0, -1, `HPE_PAUSED` */
@@ -49,6 +51,7 @@ struct llhttp_settings_s {
   llhttp_cb      on_chunk_header;
   llhttp_cb      on_chunk_complete;
 
+  /* Information-only callbacks, return value is ignored */
   llhttp_cb      on_url_complete;
   llhttp_cb      on_status_complete;
   llhttp_cb      on_header_field_complete;


### PR DESCRIPTION
`HPE_USER` return value was allowed in span callbacks (`on_body`, etc),
but wasn't in the documentation. Additionally, looking at the return
values of other documented callbacks it was easy to assume that `-1` was
a valid return value for spans as well. Instead of returning it as it
is change it to `HPE_USER` and add automatic error reason with the
span's name.

See: https://github.com/envoyproxy/envoy/pull/15814#issuecomment-822088817

cc @nodejs/http 