### PR TITLE
c-headers: do not list PRI as a valid HTTP method

### DIFF
--- a/src/llhttp/c-headers.ts
+++ b/src/llhttp/c-headers.ts
@@ -18,7 +18,9 @@ export class CHeaders {
 
     const errorMap = enumToMap(constants.ERROR);
     const methodMap = enumToMap(constants.METHODS);
-    const httpMethodMap = enumToMap(constants.METHODS, constants.METHODS_HTTP);
+    const httpMethodMap = enumToMap(constants.METHODS, constants.METHODS_HTTP, [
+      constants.METHODS.PRI,
+    ]);
     const rtspMethodMap = enumToMap(constants.METHODS, constants.METHODS_RTSP);
 
     res += this.buildEnum('llhttp_errno', 'HPE', errorMap);

--- a/src/llhttp/utils.ts
+++ b/src/llhttp/utils.ts
@@ -2,7 +2,11 @@ export interface IEnumMap {
   [key: string]: number;
 }
 
-export function enumToMap(obj: any, filter?: ReadonlyArray<number>): IEnumMap {
+export function enumToMap(
+  obj: any,
+  filter?: ReadonlyArray<number>,
+  exceptions?: ReadonlyArray<number>,
+): IEnumMap {
   const res: IEnumMap = {};
 
   Object.keys(obj).forEach((key) => {
@@ -11,6 +15,9 @@ export function enumToMap(obj: any, filter?: ReadonlyArray<number>): IEnumMap {
       return;
     }
     if (filter && !filter.includes(value)) {
+      return;
+    }
+    if (exceptions && exceptions.includes(value)) {
       return;
     }
     res[key] = value;


### PR DESCRIPTION
PRI gets special treatment (parse preamble and error) and even though it
is parsed and allowed after `HTTP/1.x` - it is not technically a method
that could appear in the request parsed with llhttp. Remove the method
from the list of HTTP methods in C headers to prevent confusion and
breakage of `body-parser`.

See: https://github.com/nodejs/llhttp/pull/103#issuecomment-823114289

# C header changes

```diff
diff --git a/tmp/llhttp-old.h b/tmp/llhttp-new.h
index fd1fdb9..0b06170 100644
--- a/tmp/llhttp-old.h
+++ b/tmp/llhttp-new.h
@@ -231,7 +231,6 @@ typedef enum llhttp_method llhttp_method_t;
   XX(31, LINK, LINK) \
   XX(32, UNLINK, UNLINK) \
   XX(33, SOURCE, SOURCE) \
-  XX(34, PRI, PRI) \
 
 
 #define RTSP_METHOD_MAP(XX) \
```

cc @nodejs/http 