### PR TITLE
Add fuzzing set up

### DIFF
--- a/test/fuzzers/fuzz_parser.c
+++ b/test/fuzzers/fuzz_parser.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "llhttp.h"
+
+llhttp_t parser;
+llhttp_settings_t settings;
+
+int handle_on_message_complete(llhttp_t* arg) {
+	return 0;
+}
+
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	/* Initialize user callbacks and settings */
+	llhttp_settings_init(&settings);
+
+	/* Set user callback */
+	settings.on_message_complete = handle_on_message_complete;
+	llhttp_init(&parser, HTTP_BOTH, &settings);
+	llhttp_execute(&parser, data, size);
+
+	return 0;
+}

--- a/test/fuzzers/fuzz_parser.c
+++ b/test/fuzzers/fuzz_parser.c
@@ -1,24 +1,45 @@
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
 #include "llhttp.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-llhttp_t parser;
-llhttp_settings_t settings;
-
-int handle_on_message_complete(llhttp_t* arg) {
-	return 0;
-}
-
+int handle_on_message_complete(llhttp_t *arg) { return 0; }
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-	/* Initialize user callbacks and settings */
-	llhttp_settings_init(&settings);
+  llhttp_t parser;
+  llhttp_settings_t settings;
+  llhttp_type_t http_type;
 
-	/* Set user callback */
-	settings.on_message_complete = handle_on_message_complete;
-	llhttp_init(&parser, HTTP_BOTH, &settings);
-	llhttp_execute(&parser, data, size);
+  /* We need four bytes to determine variable parameters */
+  if (size < 4) {
+    return 0;
+  }
 
-	return 0;
+  int headers = (data[0] & 0x01) == 1;
+  int chunked_length = (data[1] & 0x01) == 1;
+  int keep_alive = (data[2] & 0x01) == 1;
+  if (data[0] % 3 == 0) {
+    http_type = HTTP_BOTH;
+  } else if (data[0] % 3 == 1) {
+    http_type = HTTP_REQUEST;
+  } else {
+    http_type = HTTP_RESPONSE;
+  }
+  data += 4;
+  size -= 4;
+
+  /* Initialize user callbacks and settings */
+  llhttp_settings_init(&settings);
+
+  /* Set user callback */
+  settings.on_message_complete = handle_on_message_complete;
+
+  llhttp_init(&parser, http_type, &settings);
+  llhttp_set_lenient_headers(&parser, headers);
+  llhttp_set_lenient_chunked_length(&parser, chunked_length);
+  llhttp_set_lenient_keep_alive(&parser, keep_alive);
+
+  llhttp_execute(&parser, data, size);
+
+  return 0;
 }


### PR DESCRIPTION
This adds a fuzzing set up to llhttp and OSS-Fuzz - much similar to what we did with http-parser: https://github.com/nodejs/http-parser/tree/master/fuzzers

The OSS-Fuzz set up here: https://github.com/google/oss-fuzz/pull/5850

Is this something you would be interested in? it would be great to get the parser fuzzed - the only thing we will need is an email(s) that will receive bug reports, coverage reports and more. 

