### PR TITLE
pass more info in wasm_on_header_complete

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -50,8 +50,7 @@ extern int wasm_on_headers_complete(llhttp_t * p);
 extern int wasm_on_body(llhttp_t* p, const char* at, size_t length);
 extern int wasm_on_message_complete(llhttp_t * p);
 
-int on_headers_complete(llhttp_t * p)
-{
+static int wasm_on_headers_complete_wrap(llhttp_t * p) {
   return wasm_on_headers_complete(p, p->status_code, p->upgrade, llhttp_should_keep_alive(p));
 }
 
@@ -61,7 +60,7 @@ const llhttp_settings_t wasm_settings = {
   wasm_on_status,
   wasm_on_header_field,
   wasm_on_header_value,
-  on_headers_complete,
+  wasm_on_headers_complete_wrap,
   wasm_on_body,
   wasm_on_message_complete,
   NULL,

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -50,13 +50,18 @@ extern int wasm_on_headers_complete(llhttp_t * p);
 extern int wasm_on_body(llhttp_t* p, const char* at, size_t length);
 extern int wasm_on_message_complete(llhttp_t * p);
 
+int on_headers_complete(llhttp_t * p)
+{
+  return wasm_on_headers_complete(p, p->status_code, p->upgrade, llhttp_should_keep_alive(p));
+}
+
 const llhttp_settings_t wasm_settings = {
   wasm_on_message_begin,
   wasm_on_url,
   wasm_on_status,
   wasm_on_header_field,
   wasm_on_header_value,
-  wasm_on_headers_complete,
+  on_headers_complete,
   wasm_on_body,
   wasm_on_message_complete,
   NULL,


### PR DESCRIPTION
Avoids the need for additional calls into wasm.