### PR TITLE
Also copy libllhttp.pc.in to release directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ release: generate
 	cp -rf src/llhttp.gyp release/
 	cp -rf src/common.gypi release/
 	cp -rf CMakeLists.txt release/
+	cp -rf libllhttp.pc.in release/
 	cp -rf README.md release/
 	cp -rf LICENSE-MIT release/
 


### PR DESCRIPTION
See also: https://github.com/nodejs/llhttp/pull/125

Fixes:

```
$ npm install
$ make release
$ cmake -S release -B releasebuild
[…]
CMake Error: File /home/ben/src/forks/llhttp/release/libllhttp.pc.in does not exist.
CMake Error at CMakeLists.txt:41 (configure_file):
  configure_file Problem configuring file
[…]
```