### PR TITLE
api: make the wasm methods public

### DIFF
--- a/src/native/api.h
+++ b/src/native/api.h
@@ -68,8 +68,6 @@ LLHTTP_EXPORT
 void llhttp_init(llhttp_t* parser, llhttp_type_t type,
                  const llhttp_settings_t* settings);
 
-#if defined(__wasm__)
-
 LLHTTP_EXPORT
 llhttp_t* llhttp_alloc(llhttp_type_t type);
 
@@ -93,8 +91,6 @@ int llhttp_get_status_code(llhttp_t* parser);
 
 LLHTTP_EXPORT
 uint8_t llhttp_get_upgrade(llhttp_t* parser);
-
-#endif  // defined(__wasm__)
 
 /* Reset an already initialized parser back to the start state, preserving the
  * existing parser type, callback settings, user data, and lenient flags.


### PR DESCRIPTION
## Description

For non wasm compiles, there is no API for us to access attributes such as HTTP method and status code, as described in #111.