### PR TITLE
readme: add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ if (err == HPE_OK) {
 ```
 For more information on API usage, please refer to [src/native/api.h](https://github.com/nodejs/llhttp/blob/main/src/native/api.h).
 
-## Installation
+## Build Instructions
 
 Make sure you have [Node.js](https://nodejs.org/), npm and npx installed. Then under project directory run:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ if (err == HPE_OK) {
 ```
 For more information on API usage, please refer to [src/native/api.h](https://github.com/nodejs/llhttp/blob/main/src/native/api.h).
 
+## Installation
+
+Make sure you have [Node.js](https://nodejs.org/), npm and npx installed. Then under project directory run:
+
+```sh
+npm install
+make
+```
+
 ---
 
 ### Bindings to other languages


### PR DESCRIPTION
## Description

When I build this project the first time, what I got after running `make` was:
```
npx: command not found
```

So I googled around and installed `nodejs` and other stuff. But then `npm` told me it failed to compile, so I spent more time to found that I have to run `npm i` for the unmet dependencies. So I think maybe a short guidance in the README would be great.