### PR TITLE
corrections to Makefile and CMakeLists.txt for correct releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5.1)
 cmake_policy(SET CMP0069 NEW)
 
-project(llhttp VERSION 6.0.5)
+project(llhttp VERSION _TAG_)
 include(GNUInstallDirs)
 
 set(CMAKE_C_STANDARD 99)

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ release: generate
 	cp -rf src/llhttp.gyp release/
 	cp -rf src/common.gypi release/
 	cp -rf CMakeLists.txt release/
+	sed -i s/_TAG_/$(TAG)/ release/CMakeLists.txt
 	cp -rf libllhttp.pc.in release/
 	cp -rf README.md release/
 	cp -rf LICENSE-MIT release/
@@ -60,7 +61,7 @@ postversion: release
 	git checkout release --
 	cp -rf release/* ./
 	rm -rf release
-	git add include src *.gyp *.gypi CMakeLists.txt README.md LICENSE-MIT
+	git add include src *.gyp *.gypi CMakeLists.txt README.md LICENSE-MIT libllhttp.pc.in
 	git commit -a -m "release: $(TAG)"
 	git tag "release/v$(TAG)"
 	git push && git push --tags


### PR DESCRIPTION
1. replace previous "VERSION 6.0.5" by "VERSION \_TAG\_" in CMakelists.txt
2. e.g. "TAG=6.0.7 make release" will now use sed to replace \_TAG\_ by 6.0.7 in release/CMakeLists.txt
3.  "make release" will also now include the recent addition libllhttp.pc.in  when updating the release branch.