### PR TITLE
Remove a __wasm__  define guard around public APIs

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -80,6 +80,8 @@ void llhttp_free(llhttp_t* parser) {
   free(parser);
 }
 
+#endif  // defined(__wasm__)
+
 /* Some getters required to get stuff from the parser */
 
 uint8_t llhttp_get_type(llhttp_t* parser) {
@@ -105,8 +107,6 @@ int llhttp_get_status_code(llhttp_t* parser) {
 uint8_t llhttp_get_upgrade(llhttp_t* parser) {
   return parser->upgrade;
 }
-
-#endif  // defined(__wasm__)
 
 
 void llhttp_reset(llhttp_t* parser) {


### PR DESCRIPTION
Hi,

while writing LuaJIT bindings for this library I noticed something peculiar:

* In [this merged PR](https://github.com/nodejs/llhttp/pull/142/files) certain wasm APIs were made public *in the header file only*
* The implementation itself is however [still guarded by the WebAssembly define](https://github.com/nodejs/llhttp/blob/0560647932f277192a120b9aad57da13016bedaa/src/native/api.c#L42-L109)
* As a result, [the define is still present in the latest release](https://github.com/nodejs/llhttp/blob/6d954cbdc7f641f0a63a4427cf4d6be397f74ee8/src/api.c#L42-L109), which I've been using

Accordingly, I'm unable to bind these functions (without hacks). This PR should fix the problem, hopefully without side effects.

Since I'm not sure about the wasm stuff I simply moved the define upwards instead of completely deleting it.