### PR TITLE
http: added chunked extensions parsing and related callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The following callbacks can return `0` (proceed normally), `-1` (error) or `HPE_
 * `on_header_field_complete`: Invoked after a header name has been parsed.
 * `on_header_value_complete`: Invoked after a header value has been parsed.
 * `on_chunk_header`: Invoked after a new chunk is started. The current chunk length is stored in `parser->content_length`.
+* `on_chunk_extension_name_complete`: Invoked after a chunk extension name is started.
+* `on_chunk_extension_value_complete`: Invoked after a chunk extension value is started.
 * `on_chunk_complete`: Invoked after a new chunk is received. 
 * `on_reset`: Invoked after `on_message_complete` and before `on_message_begin` when a new message 
    is received on the same parser. This is not invoked for the first message of the parser.
@@ -123,6 +125,8 @@ The following callbacks can return `0` (proceed normally), `-1` (error) or `HPE_
 * `on_version`: Invoked when another character of the version is received.
 * `on_header_field`: Invoked when another character of a header name is received.
 * `on_header_value`: Invoked when another character of a header value is received.
+* `on_chunk_extension_name`: Invoked when another character of a chunk extension name is received.
+* `on_chunk_extension_value`: Invoked when another character of a extension value is received.
 
 The callback `on_headers_complete`, invoked when headers are completed, can return:
 

--- a/src/llhttp/constants.ts
+++ b/src/llhttp/constants.ts
@@ -42,6 +42,8 @@ export enum ERROR {
   CB_VERSION_COMPLETE = 33,
   CB_HEADER_FIELD_COMPLETE = 28,
   CB_HEADER_VALUE_COMPLETE = 29,
+  CB_CHUNK_EXTENSION_NAME_COMPLETE = 34,
+  CB_CHUNK_EXTENSION_VALUE_COMPLETE = 35,
   CB_RESET = 31,
 }
 
@@ -429,6 +431,13 @@ for (let i = 32; i <= 255; i++) {
 // ',' = \x44
 export const CONNECTION_TOKEN_CHARS: CharList =
   HEADER_CHARS.filter((c: string | number) => c !== 44);
+
+export const QUOTED_STRING: CharList = [ '\t', ' ' ];
+for (let i = 0x21; i <= 0xff; i++) {
+  if (i !== 0x22 && i !== 0x5c) { // All characters in ASCII except \ and "
+    QUOTED_STRING.push(i);
+  }
+}
 
 export const MAJOR = NUM_MAP;
 export const MINOR = MAJOR;

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -64,9 +64,13 @@ const llhttp_settings_t wasm_settings = {
   NULL,
   wasm_on_header_field,
   wasm_on_header_value,
+  NULL,
+  NULL,
   wasm_on_headers_complete_wrap,
   wasm_on_body,
   wasm_on_message_complete,
+  NULL,
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -401,11 +405,40 @@ int llhttp__on_chunk_header(llhttp_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_chunk_extension_name(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_chunk_extension_name, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_chunk_extension_name_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_chunk_extension_name_complete);
+  return err;
+}
+
+
+int llhttp__on_chunk_extension_value(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  SPAN_CALLBACK_MAYBE(s, on_chunk_extension_value, p, endp - p);
+  return err;
+}
+
+
+int llhttp__on_chunk_extension_value_complete(llhttp_t* s, const char* p, const char* endp) {
+  int err;
+  CALLBACK_MAYBE(s, on_chunk_extension_value_complete);
+  return err;
+}
+
+
 int llhttp__on_chunk_complete(llhttp_t* s, const char* p, const char* endp) {
   int err;
   CALLBACK_MAYBE(s, on_chunk_complete);
   return err;
 }
+
 
 int llhttp__on_reset(llhttp_t* s, const char* p, const char* endp) {
   int err;

--- a/src/native/api.h
+++ b/src/native/api.h
@@ -28,6 +28,8 @@ struct llhttp_settings_s {
   llhttp_data_cb on_version;
   llhttp_data_cb on_header_field;
   llhttp_data_cb on_header_value;
+  llhttp_data_cb      on_chunk_extension_name;
+  llhttp_data_cb      on_chunk_extension_value;
 
   /* Possible return values:
    * 0  - Proceed normally
@@ -51,6 +53,8 @@ struct llhttp_settings_s {
   llhttp_cb      on_version_complete;
   llhttp_cb      on_header_field_complete;
   llhttp_cb      on_header_value_complete;
+  llhttp_cb      on_chunk_extension_name_complete;
+  llhttp_cb      on_chunk_extension_value_complete;
 
   /* When on_chunk_header is called, the current chunk length is stored
    * in parser->content_length.

--- a/test/fixtures/extra.c
+++ b/test/fixtures/extra.c
@@ -305,6 +305,50 @@ int llhttp__on_chunk_header(llparse_t* s, const char* p, const char* endp) {
 }
 
 
+int llhttp__on_chunk_extension_name(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+
+  return llparse__print_span("chunk_extension_name", p, endp);
+}
+
+
+int llhttp__on_chunk_extension_name_complete(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+
+  llparse__print(p, endp, "chunk_extension_name complete");
+
+  #ifdef LLHTTP__TEST_PAUSE_ON_CHUNK_EXTENSION_NAME
+    return LLPARSE__ERROR_PAUSE;
+  #else
+    return 0;
+  #endif
+}
+
+
+int llhttp__on_chunk_extension_value(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+
+  return llparse__print_span("chunk_extension_value", p, endp);
+}
+
+
+int llhttp__on_chunk_extension_value_complete(llparse_t* s, const char* p, const char* endp) {
+  if (llparse__in_bench)
+    return 0;
+
+  llparse__print(p, endp, "chunk_extension_value complete");
+
+  #ifdef LLHTTP__TEST_PAUSE_ON_CHUNK_EXTENSION_VALUE
+    return LLPARSE__ERROR_PAUSE;
+  #else
+    return 0;
+  #endif
+}
+
+
 int llhttp__on_chunk_complete(llparse_t* s, const char* p, const char* endp) {
   if (llparse__in_bench)
     return 0;

--- a/test/md-test.ts
+++ b/test/md-test.ts
@@ -261,6 +261,10 @@ function run(name: string): void {
 
       for (const mode of modes) {
         for (const ty of types) {
+          if (meta.skip === true || (process.env.ONLY === 'true' && !meta.only)) {
+            continue;
+          }
+
           runSingleTest(mode, ty, meta, input, fullExpected);
         }
       }

--- a/test/request/pausing.md
+++ b/test/request/pausing.md
@@ -262,6 +262,87 @@ off=66 chunk complete
 off=66 message complete
 ```
 
+### on_chunk_extension_name
+
+<!-- meta={"type": "request", "pause": "on_chunk_extension_name"} -->
+```http
+PUT / HTTP/1.1
+Transfer-Encoding: chunked
+
+a;foo=bar
+0123456789
+0
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=3 span[method]="PUT"
+off=3 method complete
+off=4 len=1 span[url]="/"
+off=6 url complete
+off=11 len=3 span[version]="1.1"
+off=14 version complete
+off=16 len=17 span[header_field]="Transfer-Encoding"
+off=34 header_field complete
+off=35 len=7 span[header_value]="chunked"
+off=44 header_value complete
+off=46 headers complete method=4 v=1/1 flags=208 content_length=0
+off=48 len=3 span[chunk_extension_name]="foo"
+off=52 chunk_extension_name complete
+off=52 pause
+off=52 len=3 span[chunk_extension_value]="bar"
+off=56 chunk_extension_value complete
+off=57 chunk header len=10
+off=57 len=10 span[body]="0123456789"
+off=69 chunk complete
+off=72 chunk header len=0
+off=74 chunk complete
+off=74 message complete
+```
+
+### on_chunk_extension_value
+
+<!-- meta={"type": "request", "pause": "on_chunk_extension_value"} -->
+```http
+PUT / HTTP/1.1
+Transfer-Encoding: chunked
+
+a;foo=bar
+0123456789
+0
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=3 span[method]="PUT"
+off=3 method complete
+off=4 len=1 span[url]="/"
+off=6 url complete
+off=11 len=3 span[version]="1.1"
+off=14 version complete
+off=16 len=17 span[header_field]="Transfer-Encoding"
+off=34 header_field complete
+off=35 len=7 span[header_value]="chunked"
+off=44 header_value complete
+off=46 headers complete method=4 v=1/1 flags=208 content_length=0
+off=48 len=3 span[chunk_extension_name]="foo"
+off=52 chunk_extension_name complete
+off=52 len=3 span[chunk_extension_value]="bar"
+off=56 chunk_extension_value complete
+off=56 pause
+off=57 chunk header len=10
+off=57 len=10 span[body]="0123456789"
+off=69 chunk complete
+off=72 chunk header len=0
+off=74 chunk complete
+off=74 message complete
+```
+
+
 ### on_chunk_complete
 
 <!-- meta={"type": "request", "pause": "on_chunk_complete"} -->

--- a/test/response/pausing.md
+++ b/test/response/pausing.md
@@ -218,6 +218,82 @@ off=67 chunk complete
 off=67 message complete
 ```
 
+### on_chunk_extension_name
+
+<!-- meta={"type": "response", "pause": "on_chunk_extension_name"} -->
+```http
+HTTP/1.1 200 OK
+Transfer-Encoding: chunked
+
+a;foo=bar
+0123456789
+0
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=2 span[status]="OK"
+off=17 status complete
+off=17 len=17 span[header_field]="Transfer-Encoding"
+off=35 header_field complete
+off=36 len=7 span[header_value]="chunked"
+off=45 header_value complete
+off=47 headers complete status=200 v=1/1 flags=208 content_length=0
+off=49 len=3 span[chunk_extension_name]="foo"
+off=53 chunk_extension_name complete
+off=53 pause
+off=53 len=3 span[chunk_extension_value]="bar"
+off=57 chunk_extension_value complete
+off=58 chunk header len=10
+off=58 len=10 span[body]="0123456789"
+off=70 chunk complete
+off=73 chunk header len=0
+off=75 chunk complete
+off=75 message complete
+```
+
+### on_chunk_extension_value
+
+<!-- meta={"type": "response", "pause": "on_chunk_extension_value"} -->
+```http
+HTTP/1.1 200 OK
+Transfer-Encoding: chunked
+
+a;foo=bar
+0123456789
+0
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=2 span[status]="OK"
+off=17 status complete
+off=17 len=17 span[header_field]="Transfer-Encoding"
+off=35 header_field complete
+off=36 len=7 span[header_value]="chunked"
+off=45 header_value complete
+off=47 headers complete status=200 v=1/1 flags=208 content_length=0
+off=49 len=3 span[chunk_extension_name]="foo"
+off=53 chunk_extension_name complete
+off=53 len=3 span[chunk_extension_value]="bar"
+off=57 chunk_extension_value complete
+off=57 pause
+off=58 chunk header len=10
+off=58 len=10 span[body]="0123456789"
+off=70 chunk complete
+off=73 chunk header len=0
+off=75 chunk complete
+off=75 message complete
+```
+
 ### on_chunk_complete
 
 <!-- meta={"type": "response", "pause": "on_chunk_complete"} -->

--- a/test/response/transfer-encoding.md
+++ b/test/response/transfer-encoding.md
@@ -38,7 +38,7 @@ off=73 headers complete status=200 v=1/1 flags=208 content_length=0
 off=75 error code=12 reason="Invalid character in chunk size"
 ```
 
-### `chunked` before other transfer-encoding
+## `chunked` before other transfer-encoding
 
 <!-- meta={"type": "response"} -->
 ```http
@@ -67,7 +67,7 @@ off=69 headers complete status=200 v=1/1 flags=200 content_length=0
 off=69 len=5 span[body]="World"
 ```
 
-### multiple transfer-encoding where chunked is not the last one
+## multiple transfer-encoding where chunked is not the last one
 
 <!-- meta={"type": "response"} -->
 ```http
@@ -101,7 +101,7 @@ off=89 headers complete status=200 v=1/1 flags=200 content_length=0
 off=89 len=5 span[body]="World"
 ```
 
-### `chunkedchunked` transfer-encoding does not enable chunked enconding
+## `chunkedchunked` transfer-encoding does not enable chunked enconding
 
 This check that the word `chunked` repeat more than once (with or without spaces) does not mistakenly enables chunked encoding.
 
@@ -146,7 +146,60 @@ off=77 len=1 span[body]=cr
 off=78 len=1 span[body]=lf
 ```
 
-### No semicolon before chunk parameters
+## Chunk extensions
+
+<!-- meta={"type": "response"} -->
+```http
+HTTP/1.1 200 OK
+Host: localhost
+Transfer-encoding: chunked
+
+5;ilovew3;somuchlove=aretheseparametersfor
+hello
+6;blahblah;blah
+ world
+0
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=2 span[status]="OK"
+off=17 status complete
+off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
+off=23 len=9 span[header_value]="localhost"
+off=34 header_value complete
+off=34 len=17 span[header_field]="Transfer-encoding"
+off=52 header_field complete
+off=53 len=7 span[header_value]="chunked"
+off=62 header_value complete
+off=64 headers complete status=200 v=1/1 flags=208 content_length=0
+off=66 len=7 span[chunk_extension_name]="ilovew3"
+off=74 chunk_extension_name complete
+off=74 len=10 span[chunk_extension_name]="somuchlove"
+off=85 chunk_extension_name complete
+off=85 len=21 span[chunk_extension_value]="aretheseparametersfor"
+off=107 chunk_extension_value complete
+off=108 chunk header len=5
+off=108 len=5 span[body]="hello"
+off=115 chunk complete
+off=117 len=8 span[chunk_extension_name]="blahblah"
+off=126 chunk_extension_name complete
+off=126 len=4 span[chunk_extension_name]="blah"
+off=131 chunk_extension_name complete
+off=132 chunk header len=6
+off=132 len=6 span[body]=" world"
+off=140 chunk complete
+off=143 chunk header len=0
+off=145 chunk complete
+off=145 message complete
+```
+
+## No semicolon before chunk extensions
 
 <!-- meta={"type": "response"} -->
 ```http
@@ -179,3 +232,137 @@ off=64 headers complete status=200 v=1/1 flags=208 content_length=0
 off=65 error code=12 reason="Invalid character in chunk size"
 ```
 
+
+## No extension after semicolon
+
+<!-- meta={"type": "response"} -->
+```http
+HTTP/1.1 200 OK
+Host: localhost
+Transfer-encoding: chunked
+
+2;
+aa
+0
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=2 span[status]="OK"
+off=17 status complete
+off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
+off=23 len=9 span[header_value]="localhost"
+off=34 header_value complete
+off=34 len=17 span[header_field]="Transfer-encoding"
+off=52 header_field complete
+off=53 len=7 span[header_value]="chunked"
+off=62 header_value complete
+off=64 headers complete status=200 v=1/1 flags=208 content_length=0
+off=67 error code=2 reason="Invalid character in chunk extensions"
+```
+
+
+## Chunk extensions quoting
+
+<!-- meta={"type": "response"} -->
+```http
+HTTP/1.1 200 OK
+Host: localhost
+Transfer-Encoding: chunked
+
+5;ilovew3="I love; extensions";somuchlove="aretheseparametersfor";blah;foo=bar
+hello
+6;blahblah;blah
+ world
+0
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=2 span[status]="OK"
+off=17 status complete
+off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
+off=23 len=9 span[header_value]="localhost"
+off=34 header_value complete
+off=34 len=17 span[header_field]="Transfer-Encoding"
+off=52 header_field complete
+off=53 len=7 span[header_value]="chunked"
+off=62 header_value complete
+off=64 headers complete status=200 v=1/1 flags=208 content_length=0
+off=66 len=7 span[chunk_extension_name]="ilovew3"
+off=74 chunk_extension_name complete
+off=74 len=20 span[chunk_extension_value]=""I love; extensions""
+off=94 chunk_extension_value complete
+off=95 len=10 span[chunk_extension_name]="somuchlove"
+off=106 chunk_extension_name complete
+off=106 len=23 span[chunk_extension_value]=""aretheseparametersfor""
+off=129 chunk_extension_value complete
+off=130 len=4 span[chunk_extension_name]="blah"
+off=135 chunk_extension_name complete
+off=135 len=3 span[chunk_extension_name]="foo"
+off=139 chunk_extension_name complete
+off=139 len=3 span[chunk_extension_value]="bar"
+off=143 chunk_extension_value complete
+off=144 chunk header len=5
+off=144 len=5 span[body]="hello"
+off=151 chunk complete
+off=153 len=8 span[chunk_extension_name]="blahblah"
+off=162 chunk_extension_name complete
+off=162 len=4 span[chunk_extension_name]="blah"
+off=167 chunk_extension_name complete
+off=168 chunk header len=6
+off=168 len=6 span[body]=" world"
+off=176 chunk complete
+off=179 chunk header len=0
+```
+
+
+## Unbalanced chunk extensions quoting
+
+<!-- meta={"type": "response"} -->
+```http
+HTTP/1.1 200 OK
+Host: localhost
+Transfer-Encoding: chunked
+
+5;ilovew3="abc";somuchlove="def; ghi
+hello
+6;blahblah;blah
+ world
+0
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=2 span[status]="OK"
+off=17 status complete
+off=17 len=4 span[header_field]="Host"
+off=22 header_field complete
+off=23 len=9 span[header_value]="localhost"
+off=34 header_value complete
+off=34 len=17 span[header_field]="Transfer-Encoding"
+off=52 header_field complete
+off=53 len=7 span[header_value]="chunked"
+off=62 header_value complete
+off=64 headers complete status=200 v=1/1 flags=208 content_length=0
+off=66 len=7 span[chunk_extension_name]="ilovew3"
+off=74 chunk_extension_name complete
+off=74 len=5 span[chunk_extension_value]=""abc""
+off=79 chunk_extension_value complete
+off=80 len=10 span[chunk_extension_name]="somuchlove"
+off=91 chunk_extension_name complete
+off=91 len=9 span[chunk_extension_value]=""def; ghi"
+off=101 error code=2 reason="Invalid character in chunk extensions quoted value"
+```


### PR DESCRIPTION
This PR parses chunk extensions as defined in RFC 7230.

It also add the `on_chunk_extension_name`, `on_chunk_extension_value`, `on_chunk_extension_name_complete` and `on_chunk_extension_value_complete` callbacks. 

Fixes #153.