### PR TITLE
feat: Allow to select WASM platform when using Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
-FROM node:14.16.0-buster
-
+FROM node:18-alpine
 ARG UID=1000
 ARG GID=1000
-ARG WASI_SDK_VERSION_MAJOR=12
-ARG WASI_SDK_VERSION_MINOR=0
 
-ENV WASI_ROOT=/home/node/wasi-sdk-12.0
-
-RUN wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION_MAJOR}/wasi-sdk-${WASI_SDK_VERSION_MAJOR}.${WASI_SDK_VERSION_MINOR}-linux.tar.gz -P /tmp
-
-RUN tar xvf /tmp/wasi-sdk-${WASI_SDK_VERSION_MAJOR}.${WASI_SDK_VERSION_MINOR}-linux.tar.gz --directory /home/node
-
-RUN mkdir /home/node/llhttp
+RUN apk add -U clang lld wasi-sdk && mkdir /home/node/llhttp
 
 WORKDIR /home/node/llhttp
 

--- a/bin/build_wasm.ts
+++ b/bin/build_wasm.ts
@@ -1,57 +1,67 @@
-import { execSync } from 'child_process';
-import { copyFileSync, mkdirSync, writeFileSync } from 'fs';
-import { stringify } from 'javascript-stringify';
-import { join, resolve } from 'path';
-import { constants } from '..';
+import { execSync } from 'child_process'
+import { copyFileSync, mkdirSync } from 'fs'
+import { join, resolve } from 'path'
 
-const { WASI_ROOT } = process.env;
-const WASM_OUT = resolve(__dirname, '../build/wasm');
-const WASM_SRC = resolve(__dirname, '../');
+let platform = process.env.WASM_PLATFORM ?? ''
+const WASM_OUT = resolve(__dirname, '../build/wasm')
+const WASM_SRC = resolve(__dirname, '../')
+
+if (!platform && process.argv[2]) {
+  platform = execSync('docker info -f "{{.OSType}}/{{.Architecture}}"').toString().trim()
+}
+
+if (process.argv[2] === '--prebuild') {
+  const cmd = `docker build --platform=${platform.toString().trim()} -t llhttp_wasm_builder .`
+
+  console.log(`> ${cmd}\n\n`)
+  execSync(cmd, { stdio: 'inherit' })
+
+  process.exit(0)
+}
 
 if (process.argv[2] === '--setup') {
   try {
-    mkdirSync(join(WASM_SRC, 'build'));
-    process.exit(0);
+    mkdirSync(join(WASM_SRC, 'build'))
+    process.exit(0)
   } catch (error) {
     if (error.code !== 'EEXIST') {
-      throw error;
+      throw error
     }
-    process.exit(0);
+    process.exit(0)
   }
 }
 
 if (process.argv[2] === '--docker') {
-  let cmd = 'docker run --rm -it';
+  let cmd = `docker run --rm -it --platform=${platform.toString().trim()}`
   // Try to avoid root permission problems on compiled assets
   // when running on linux.
   // It will work flawessly if uid === gid === 1000
   // there will be some warnings otherwise.
   if (process.platform === 'linux') {
-    cmd += ` --user ${process.getuid()}:${process.getegid()}`;
+    cmd += ` --user ${process.getuid()}:${process.getegid()}`
   }
-  cmd += ` --mount type=bind,source=${WASM_SRC}/build,target=/home/node/llhttp/build llhttp_wasm_builder npm run wasm`;
-  execSync(cmd, { cwd: WASM_SRC, stdio: 'inherit' });
-  process.exit(0);
-}
+  cmd += ` --mount type=bind,source=${WASM_SRC}/build,target=/home/node/llhttp/build llhttp_wasm_builder npm run wasm`
 
-if (!WASI_ROOT) {
-  throw new Error('Please setup the WASI_ROOT env variable.');
+  console.log(`> ${cmd}\n\n`)
+  execSync(cmd, { cwd: WASM_SRC, stdio: 'inherit' })
+  process.exit(0)
 }
 
 try {
-  mkdirSync(WASM_OUT);
+  mkdirSync(WASM_OUT)
 } catch (error) {
   if (error.code !== 'EEXIST') {
-    throw error;
+    throw error
   }
 }
 
 // Build ts
-execSync('npm run build', { cwd: WASM_SRC, stdio: 'inherit' });
+execSync('npm run build', { cwd: WASM_SRC, stdio: 'inherit' })
 
 // Build wasm binary
-execSync(`${WASI_ROOT}/bin/clang \
- --sysroot=${WASI_ROOT}/share/wasi-sysroot \
+execSync(
+  `clang \
+ --sysroot=/usr/share/wasi-sysroot \
  -target wasm32-unknown-wasi \
  -Ofast \
  -fno-exceptions \
@@ -66,15 +76,18 @@ execSync(`${WASI_ROOT}/bin/clang \
  -Wl,--export-table \
  -Wl,--export=malloc \
  -Wl,--export=free \
+ -Wl,--no-entry \
  ${join(WASM_SRC, 'build', 'c')}/*.c \
  ${join(WASM_SRC, 'src', 'native')}/*.c \
  -I${join(WASM_SRC, 'build')} \
- -o ${join(WASM_OUT, 'llhttp.wasm')}`, { stdio: 'inherit' });
+ -o ${join(WASM_OUT, 'llhttp.wasm')}`,
+  { stdio: 'inherit' }
+)
 
 // Copy constants for `.js` and `.ts` users.
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js'), join(WASM_OUT, 'constants.js'));
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js.map'), join(WASM_OUT, 'constants.js.map'));
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.d.ts'), join(WASM_OUT, 'constants.d.ts'));
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js'), join(WASM_OUT, 'utils.js'));
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js.map'), join(WASM_OUT, 'utils.js.map'));
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.d.ts'), join(WASM_OUT, 'utils.d.ts'));
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js'), join(WASM_OUT, 'constants.js'))
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js.map'), join(WASM_OUT, 'constants.js.map'))
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.d.ts'), join(WASM_OUT, 'constants.d.ts'))
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js'), join(WASM_OUT, 'utils.js'))
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js.map'), join(WASM_OUT, 'utils.js.map'))
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.d.ts'), join(WASM_OUT, 'utils.d.ts'))

--- a/bin/build_wasm.ts
+++ b/bin/build_wasm.ts
@@ -1,62 +1,64 @@
-import { execSync } from 'child_process'
-import { copyFileSync, mkdirSync } from 'fs'
-import { join, resolve } from 'path'
+import { execSync } from 'child_process';
+import { copyFileSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
 
-let platform = process.env.WASM_PLATFORM ?? ''
-const WASM_OUT = resolve(__dirname, '../build/wasm')
-const WASM_SRC = resolve(__dirname, '../')
+let platform = process.env.WASM_PLATFORM ?? '';
+const WASM_OUT = resolve(__dirname, '../build/wasm');
+const WASM_SRC = resolve(__dirname, '../');
 
 if (!platform && process.argv[2]) {
-  platform = execSync('docker info -f "{{.OSType}}/{{.Architecture}}"').toString().trim()
+  platform = execSync('docker info -f "{{.OSType}}/{{.Architecture}}"').toString().trim();
 }
 
 if (process.argv[2] === '--prebuild') {
-  const cmd = `docker build --platform=${platform.toString().trim()} -t llhttp_wasm_builder .`
+  const cmd = `docker build --platform=${platform.toString().trim()} -t llhttp_wasm_builder .`;
 
-  console.log(`> ${cmd}\n\n`)
-  execSync(cmd, { stdio: 'inherit' })
+  /* tslint:disable-next-line no-console */
+  console.log(`> ${cmd}\n\n`);
+  execSync(cmd, { stdio: 'inherit' });
 
-  process.exit(0)
+  process.exit(0);
 }
 
 if (process.argv[2] === '--setup') {
   try {
-    mkdirSync(join(WASM_SRC, 'build'))
-    process.exit(0)
+    mkdirSync(join(WASM_SRC, 'build'));
+    process.exit(0);
   } catch (error) {
     if (error.code !== 'EEXIST') {
-      throw error
+      throw error;
     }
-    process.exit(0)
+    process.exit(0);
   }
 }
 
 if (process.argv[2] === '--docker') {
-  let cmd = `docker run --rm -it --platform=${platform.toString().trim()}`
+  let cmd = `docker run --rm -it --platform=${platform.toString().trim()}`;
   // Try to avoid root permission problems on compiled assets
   // when running on linux.
   // It will work flawessly if uid === gid === 1000
   // there will be some warnings otherwise.
   if (process.platform === 'linux') {
-    cmd += ` --user ${process.getuid()}:${process.getegid()}`
+    cmd += ` --user ${process.getuid()}:${process.getegid()}`;
   }
-  cmd += ` --mount type=bind,source=${WASM_SRC}/build,target=/home/node/llhttp/build llhttp_wasm_builder npm run wasm`
+  cmd += ` --mount type=bind,source=${WASM_SRC}/build,target=/home/node/llhttp/build llhttp_wasm_builder npm run wasm`;
 
-  console.log(`> ${cmd}\n\n`)
-  execSync(cmd, { cwd: WASM_SRC, stdio: 'inherit' })
-  process.exit(0)
+  /* tslint:disable-next-line no-console */
+  console.log(`> ${cmd}\n\n`);
+  execSync(cmd, { cwd: WASM_SRC, stdio: 'inherit' });
+  process.exit(0);
 }
 
 try {
-  mkdirSync(WASM_OUT)
+  mkdirSync(WASM_OUT);
 } catch (error) {
   if (error.code !== 'EEXIST') {
-    throw error
+    throw error;
   }
 }
 
 // Build ts
-execSync('npm run build', { cwd: WASM_SRC, stdio: 'inherit' })
+execSync('npm run build', { cwd: WASM_SRC, stdio: 'inherit' });
 
 // Build wasm binary
 execSync(
@@ -81,13 +83,13 @@ execSync(
  ${join(WASM_SRC, 'src', 'native')}/*.c \
  -I${join(WASM_SRC, 'build')} \
  -o ${join(WASM_OUT, 'llhttp.wasm')}`,
-  { stdio: 'inherit' }
-)
+  { stdio: 'inherit' },
+);
 
 // Copy constants for `.js` and `.ts` users.
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js'), join(WASM_OUT, 'constants.js'))
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js.map'), join(WASM_OUT, 'constants.js.map'))
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.d.ts'), join(WASM_OUT, 'constants.d.ts'))
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js'), join(WASM_OUT, 'utils.js'))
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js.map'), join(WASM_OUT, 'utils.js.map'))
-copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.d.ts'), join(WASM_OUT, 'utils.d.ts'))
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js'), join(WASM_OUT, 'constants.js'));
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.js.map'), join(WASM_OUT, 'constants.js.map'));
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'constants.d.ts'), join(WASM_OUT, 'constants.d.ts'));
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js'), join(WASM_OUT, 'utils.js'));
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.js.map'), join(WASM_OUT, 'utils.js.map'));
+copyFileSync(join(WASM_SRC, 'lib', 'llhttp', 'utils.d.ts'), join(WASM_OUT, 'utils.d.ts'));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bench": "ts-node bench/",
     "build": "ts-node bin/generate.ts",
     "build-ts": "tsc",
-    "prebuild-wasm": "docker build -t llhttp_wasm_builder . && npm run wasm -- --setup",
+    "prebuild-wasm": "npm run wasm -- --prebuild && npm run wasm -- --setup",
     "build-wasm": "npm run wasm -- --docker",
     "wasm": "ts-node bin/build_wasm.ts",
     "clean": "rm -rf lib && rm -rf test/tmp",


### PR DESCRIPTION
I've added a `process.env.WASM_PLATFORM` to the build script to select the platform to build Docker image for.
Also, I've updated Docker image to be smaller and to use Node 16 to build.

Fixes #208.