### PR TITLE
Stricter parsing of status line

### DIFF
--- a/test/response/invalid.md
+++ b/test/response/invalid.md
@@ -149,3 +149,53 @@ off=13 len=2 span[status]="OK"
 off=17 status complete
 off=18 error code=30 reason="Unexpected space after start line"
 ```
+
+### Extra space between HTTP version and status code
+
+<!-- meta={"type": "response-only"} -->
+```http
+HTTP/1.1  200 OK
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=9 error code=13 reason="Invalid status code"
+```
+
+### Extra space between status code and reason
+
+<!-- meta={"type": "response-only"} -->
+```http
+HTTP/1.1 200  OK
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=13 len=3 span[status]=" OK"
+off=18 status complete
+off=20 headers complete status=200 v=1/1 flags=0 content_length=0
+```
+
+### One-digit status code
+
+<!-- meta={"type": "response-only"} -->
+```http
+HTTP/1.1 2 OK
+
+
+```
+
+```log
+off=0 message begin
+off=5 len=3 span[version]="1.1"
+off=8 version complete
+off=10 error code=13 reason="Invalid status code"
+```


### PR DESCRIPTION
Stricter parsing of status line

Background:
llhttp currently does not handle extra spaces in the status line correctly

This snippet:
```http
HTTP/1.1  200  OK


```
Is parsed as status=0, v=1/1, reason = `' OK'`, which is clearly not correct.

This PR rejects a status line with more than one space between HTTP version and status code, and also requires that the status code is exactly 3 digits as per the relevant section on [RFC7230](https://www.rfc-editor.org/rfc/rfc7230#page-22) which says that a status line is:
> status-line = HTTP-version SP status-code SP reason-phrase CRLF