### PR TITLE
Fix HTTP benchmark

### DIFF
--- a/bench/index.ts
+++ b/bench/index.ts
@@ -71,7 +71,7 @@ if (isURL) {
 }
 
 if (isHTTP) {
-  for(const [request, name] of requests) {
+  for(const [name, request] of requests) {
     console.log('http loose: "%s" (C)', name);
 
     spawnSync('./test/tmp/http-loose-request-c', [


### PR DESCRIPTION
Fixes a bug introduced in 7b292f2, which has rendered the HTTP benchmark feature non-functional.