### PR TITLE
[v6.x] fix: Do not allow empty header separated by CR.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ release: generate
 	cp -rf src/llhttp.gyp release/
 	cp -rf src/common.gypi release/
 	cp -rf CMakeLists.txt release/
-	sed -i s/_TAG_/$(TAG)/ release/CMakeLists.txt
+	sed -i '' s/_TAG_/$(TAG)/ release/CMakeLists.txt
 	cp -rf libllhttp.pc.in release/
 	cp -rf README.md release/
 	cp -rf LICENSE-MIT release/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llhttp",
-  "version": "6.0.10",
+  "version": "6.0.11",
   "description": "HTTP parser in LLVM IR",
   "main": "lib/llhttp.js",
   "types": "lib/llhttp.d.ts",

--- a/src/llhttp.gyp
+++ b/src/llhttp.gyp
@@ -1,4 +1,11 @@
 {
+  'variables': {
+    'llhttp_sources': [
+      'src/llhttp.c',
+      'src/api.c',
+      'src/http.c',
+    ]
+  },
   'targets': [
     {
       'target_name': 'llhttp',
@@ -7,7 +14,9 @@
       'direct_dependent_settings': {
         'include_dirs': [ 'include' ],
       },
-      'sources': [ 'src/llhttp.c', 'src/api.c', 'src/http.c' ],
+      'sources': [
+        '<@(llhttp_sources)',
+      ],
     },
   ]
 }

--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -481,14 +481,13 @@ export class HTTP {
       }, p.error(ERROR.INVALID_HEADER_TOKEN, 'Invalid header value char')))
       .otherwise(span.headerValue.start(n('header_value_start')));
 
-    if (this.mode === 'strict') {
-      n('header_value_discard_ws_almost_done')
-        .match('\n', n('header_value_discard_lws'))
-        .otherwise(p.error(ERROR.STRICT, 'Expected LF after CR'));
-    } else {
-      n('header_value_discard_ws_almost_done').skipTo(
-        n('header_value_discard_lws'));
-    }
+    n('header_value_discard_ws_almost_done')
+      .match('\n', n('header_value_discard_lws'))
+      .otherwise(
+        this.testLenientFlags(LENIENT_FLAGS.HEADERS, {
+          1: n('header_value_discard_lws'),
+        }, p.error(ERROR.STRICT, 'Expected LF after CR')),
+      );
 
     const onHeaderValueComplete = p.invoke(this.callback.onHeaderValueComplete);
     onHeaderValueComplete.otherwise(n('header_field_start'));
@@ -501,7 +500,9 @@ export class HTTP {
       this.emptySpan(span.headerValue, onHeaderValueComplete)));
 
     n('header_value_discard_lws')
-      .match([ ' ', '\t' ], n('header_value_discard_ws'))
+      .match([ ' ', '\t' ], this.testLenientFlags(LENIENT_FLAGS.HEADERS, {
+        1: n('header_value_discard_ws'),
+      }, p.error(ERROR.INVALID_HEADER_TOKEN, 'Invalid header value char')))
       .otherwise(checkContentLengthEmptiness);
 
     // Multiple `Transfer-Encoding` headers should be treated as one, but with

--- a/test/request/invalid.md
+++ b/test/request/invalid.md
@@ -117,6 +117,38 @@ off=41 len=1 span[header_value]="x"
 off=42 error code=10 reason="Invalid header value char"
 ```
 
+### Empty headers separated by CR
+
+<!-- meta={"type": "request" } -->
+```http
+POST / HTTP/1.1
+Connection: Close
+Host: localhost:5000
+x:\rTransfer-Encoding: chunked
+
+1
+A
+0
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=7 url complete
+off=17 len=10 span[header_field]="Connection"
+off=28 header_field complete
+off=29 len=5 span[header_value]="Close"
+off=36 header_value complete
+off=36 len=4 span[header_field]="Host"
+off=41 header_field complete
+off=42 len=14 span[header_value]="localhost:5000"
+off=58 header_value complete
+off=58 len=1 span[header_field]="x"
+off=60 header_field complete
+off=61 error code=2 reason="Expected LF after CR"
+```
+
 ### Empty headers separated by LF
 
 <!-- meta={"type": "request"} -->

--- a/test/request/lenient-headers.md
+++ b/test/request/lenient-headers.md
@@ -80,3 +80,45 @@ off=27 header_field complete
 off=28 len=0 span[header_value]=""
 off=28 error code=10 reason="Invalid header value char"
 ```
+
+### Empty headers separated by CR (Lenient)
+
+<!-- meta={"type": "request-lenient-headers"} -->
+```http
+POST / HTTP/1.1
+Connection: Close
+Host: localhost:5000
+x:\rTransfer-Encoding: chunked
+
+1
+A
+0
+
+```
+
+```log
+off=0 message begin
+off=5 len=1 span[url]="/"
+off=7 url complete
+off=17 len=10 span[header_field]="Connection"
+off=28 header_field complete
+off=29 len=5 span[header_value]="Close"
+off=36 header_value complete
+off=36 len=4 span[header_field]="Host"
+off=41 header_field complete
+off=42 len=14 span[header_value]="localhost:5000"
+off=58 header_value complete
+off=58 len=1 span[header_field]="x"
+off=60 header_field complete
+off=61 len=0 span[header_value]=""
+off=61 header_value complete
+off=61 len=17 span[header_field]="Transfer-Encoding"
+off=79 header_field complete
+off=80 len=7 span[header_value]="chunked"
+off=89 header_value complete
+off=91 headers complete method=3 v=1/1 flags=20a content_length=0
+off=94 chunk header len=1
+off=94 len=1 span[body]="A"
+off=97 chunk complete
+off=100 chunk header len=0
+```

--- a/test/request/sample.md
+++ b/test/request/sample.md
@@ -276,7 +276,7 @@ off=9 message complete
 
 ## Line folding in header value with CRLF
 
-<!-- meta={"type": "request"} -->
+<!-- meta={"type": "request-lenient-headers"} -->
 ```http
 GET / HTTP/1.1
 Line1:   abc


### PR DESCRIPTION
This PR forbids empty header separated by CR when no leniency is allowed.

Fixes: https://hackerone.com/reports/2001873