### PR TITLE
Do not assume a particular sed implementation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,7 @@ release: clean generate
 	cp -rf src/native/*.c release/src/
 	cp -rf src/llhttp.gyp release/
 	cp -rf src/common.gypi release/
-	cp -rf CMakeLists.txt release/
-	sed -i '' s/_RELEASE_/$(RELEASE)/ release/CMakeLists.txt
+	sed s/_RELEASE_/$(RELEASE)/ CMakeLists.txt > release/CMakeLists.txt
 	cp -rf libllhttp.pc.in release/
 	cp -rf README.md release/
 	cp -rf LICENSE-MIT release/


### PR DESCRIPTION
Make the release target in the Makefile more portable.

See conversation: https://github.com/nodejs/llhttp/commit/7e18596bae8f63692ded9d3250d5d984fe90dcfb#r119290262