### PR TITLE
lenient_flags is truncated on reset

### DIFF
--- a/src/native/api.c
+++ b/src/native/api.c
@@ -126,7 +126,7 @@ void llhttp_reset(llhttp_t* parser) {
   llhttp_type_t type = parser->type;
   const llhttp_settings_t* settings = parser->settings;
   void* data = parser->data;
-  uint8_t lenient_flags = parser->lenient_flags;
+  uint16_t lenient_flags = parser->lenient_flags;
 
   llhttp__internal_init(parser);
 


### PR DESCRIPTION
Newer lenient flags `LENIENT_OPTIONAL_CR_BEFORE_LF` `LENIENT_SPACES_AFTER_CHUNK_SIZE` are lost during `llhttp_reset`