### PR TITLE
Use clean installs from MPN

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -35,7 +35,7 @@ jobs:
         key: ubuntu-latest-node-${{ hashFiles('vendor/llhttp/**/package-lock.json') }}
         restore-keys: ubuntu-latest-node-
     - name: Install llhttp dependencies
-      run: npm install --ignore-scripts
+      run: npm ci --ignore-scripts
       working-directory: vendor/llhttp
     - name: Build llhttp
       run: make

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Build libllhttp.a
         shell: bash
@@ -88,7 +88,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       # Custom script, because progress looks not good in CI
       - name: Run tests
@@ -112,7 +112,7 @@ jobs:
             ${{ runner.os }}-node-
 
       - name: Install dependencies
-        run: npm install --ignore-scripts
+        run: npm ci --ignore-scripts
 
       - name: Run lint command
         run: npm run lint

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ With this flag this check is disabled.
 Make sure you have [Node.js](https://nodejs.org/), npm and npx installed. Then under project directory run:
 
 ```sh
-npm install
+npm ci
 make
 ```
 
@@ -451,7 +451,7 @@ _Note that using the git repo directly (e.g., via a git repo url and tag) will n
 
 1. Ensure that `Clang` and `make` are in your system path.
 2. Using Git Bash, clone the repo to your preferred location.
-3. Cd into the cloned directory and run `npm install`
+3. Cd into the cloned directory and run `npm ci`
 5. Run `make`
 6. Your `repo/build` directory should now have `libllhttp.a` and `libllhttp.so` static and dynamic libraries.
 7. When building your executable, you can link to these libraries. Make sure to set the build folder as an include path when building so you can reference the declarations in `repo/build/llhttp.h`.


### PR DESCRIPTION
Currently, the README and workflows are using `npm install`, which does not preserve the lock file.  This change switches to using clean installs with `npm ci`.

Note the `Dockerfile` does already correctly use a clean install.