### PR TITLE
fix: Do not allow OBS fold in headers by default.

### DIFF
--- a/src/llhttp/http.ts
+++ b/src/llhttp/http.ts
@@ -756,11 +756,14 @@ export class HTTP {
         'Missing expected LF after header value'));
 
     n('header_value_lws')
-      .peek([ ' ', '\t' ],
-        this.load('header_state', {
-          [HEADER_STATE.TRANSFER_ENCODING_CHUNKED]:
-            this.resetHeaderState(span.headerValue.start(n('header_value_start'))),
-        }, span.headerValue.start(n('header_value_start'))))
+      .peek(
+        [ ' ', '\t' ],
+        this.testLenientFlags(LENIENT_FLAGS.HEADERS, {
+          1: this.load('header_state', {
+            [HEADER_STATE.TRANSFER_ENCODING_CHUNKED]:
+              this.resetHeaderState(span.headerValue.start(n('header_value_start'))),
+          }, span.headerValue.start(n('header_value_start'))),
+        }, p.error(ERROR.INVALID_HEADER_TOKEN, 'Unexpected whitespace after header value')))
       .otherwise(this.setHeaderFlags(onHeaderValueComplete));
 
     const checkTrailing = this.testFlags(FLAGS.TRAILING, {

--- a/test/request/connection.md
+++ b/test/request/connection.md
@@ -374,7 +374,7 @@ off=75 message complete
 
 ### Multiple tokens with folding
 
-<!-- meta={"type": "request"} -->
+<!-- meta={"type": "request-lenient-headers"} -->
 ```http
 GET /demo HTTP/1.1
 Host: example.com
@@ -465,7 +465,7 @@ off=75 error code=22 reason="Pause on CONNECT/Upgrade"
 
 ### Multiple tokens with folding, LWS, and CRLF
 
-<!-- meta={"type": "request"} -->
+<!-- meta={"type": "request-lenient-headers"} -->
 ```http
 GET /demo HTTP/1.1
 Connection: keep-alive, \r\n upgrade

--- a/test/request/invalid.md
+++ b/test/request/invalid.md
@@ -403,3 +403,88 @@ off=11 len=3 span[version]="1.1"
 off=14 version complete
 off=17 error code=30 reason="Unexpected space after start line"
 ```
+
+### Spaces before headers
+
+<!-- meta={ "type": "request" } -->
+
+```http
+POST /hello HTTP/1.1
+Host: localhost
+Foo: bar
+ Content-Length: 38
+
+GET /bye HTTP/1.1
+Host: localhost
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=4 span[method]="POST"
+off=4 method complete
+off=5 len=6 span[url]="/hello"
+off=12 url complete
+off=17 len=3 span[version]="1.1"
+off=20 version complete
+off=22 len=4 span[header_field]="Host"
+off=27 header_field complete
+off=28 len=9 span[header_value]="localhost"
+off=39 header_value complete
+off=39 len=3 span[header_field]="Foo"
+off=43 header_field complete
+off=44 len=3 span[header_value]="bar"
+off=49 error code=10 reason="Unexpected whitespace after header value"
+```
+
+### Spaces before headers (lenient)
+
+<!-- meta={ "type": "request-lenient-headers" } -->
+
+```http
+POST /hello HTTP/1.1
+Host: localhost
+Foo: bar
+ Content-Length: 38
+
+GET /bye HTTP/1.1
+Host: localhost
+
+
+```
+
+```log
+off=0 message begin
+off=0 len=4 span[method]="POST"
+off=4 method complete
+off=5 len=6 span[url]="/hello"
+off=12 url complete
+off=17 len=3 span[version]="1.1"
+off=20 version complete
+off=22 len=4 span[header_field]="Host"
+off=27 header_field complete
+off=28 len=9 span[header_value]="localhost"
+off=39 header_value complete
+off=39 len=3 span[header_field]="Foo"
+off=43 header_field complete
+off=44 len=3 span[header_value]="bar"
+off=49 len=19 span[header_value]=" Content-Length: 38"
+off=70 header_value complete
+off=72 headers complete method=3 v=1/1 flags=0 content_length=0
+off=72 message complete
+off=72 reset
+off=72 message begin
+off=72 len=3 span[method]="GET"
+off=75 method complete
+off=76 len=4 span[url]="/bye"
+off=81 url complete
+off=86 len=3 span[version]="1.1"
+off=89 version complete
+off=91 len=4 span[header_field]="Host"
+off=96 header_field complete
+off=97 len=9 span[header_value]="localhost"
+off=108 header_value complete
+off=110 headers complete method=1 v=1/1 flags=0 content_length=0
+off=110 message complete
+```

--- a/test/request/sample.md
+++ b/test/request/sample.md
@@ -497,7 +497,7 @@ off=61 message complete
 
 See nodejs/test/parallel/test-http-headers-obstext.js
 
-<!-- meta={"type": "request"} -->
+<!-- meta={"type": "request-lenient-headers"} -->
 ```http
 GET / HTTP/1.1
 X-SSL-Nonsense:   -----BEGIN CERTIFICATE-----

--- a/test/request/transfer-encoding.md
+++ b/test/request/transfer-encoding.md
@@ -854,7 +854,7 @@ off=50 error code=12 reason="Invalid character in chunk size"
 
 ## Invalid OBS fold after chunked value
 
-<!-- meta={"type": "request", "mode": "strict"} -->
+<!-- meta={"type": "request-lenient-headers", "mode": "strict"} -->
 ```http
 PUT /url HTTP/1.1
 Transfer-Encoding: chunked

--- a/test/response/transfer-encoding.md
+++ b/test/response/transfer-encoding.md
@@ -370,7 +370,7 @@ off=101 error code=2 reason="Invalid character in chunk extensions quoted value"
 
 ## Invalid OBS fold after chunked value
 
-<!-- meta={"type": "response" } -->
+<!-- meta={"type": "response-lenient-headers" } -->
 ```http
 HTTP/1.1 200 OK
 Transfer-Encoding: chunked

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "./lib",
     "declaration": true,
     "pretty": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
Ref: [CVE-2024-27982](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases/#http-request-smuggling-via-content-length-obfuscation---cve-2024-27982---medium)