### PR TITLE
compile WebAssembly in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,3 +116,36 @@ jobs:
 
       - name: Run lint command
         run: npm run lint
+
+  build-wasm:
+    name: Build WebAssembly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 1
+
+      - name: Restore node_modules cache for Linux
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        if: runner.os == 'Linux'
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prepare build
+        run: npm run prebuild-wasm
+
+      - name: Build
+        run: npm run build-wasm
+
+      - name: Upload build
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: build-wasm
+          path: build/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,12 @@ jobs:
         run: |
           make build/libllhttp.a
 
+      - name: Upload build
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: build-${{ runner.os }}
+          path: build/
+
   test:
     name: Run tests
     runs-on: ${{ matrix.os }}

--- a/bin/build_wasm.ts
+++ b/bin/build_wasm.ts
@@ -3,6 +3,7 @@ import { copyFileSync, mkdirSync } from 'fs';
 import { join, resolve } from 'path';
 
 let platform = process.env.WASM_PLATFORM ?? '';
+const IS_CI = 'CI' in process.env;
 const WASM_OUT = resolve(__dirname, '../build/wasm');
 const WASM_SRC = resolve(__dirname, '../');
 
@@ -11,7 +12,7 @@ if (!platform && process.argv[2]) {
 }
 
 if (process.argv[2] === '--prebuild') {
-  const cmd = `docker build --platform=${platform.toString().trim()} -t llhttp_wasm_builder .`;
+  const cmd = `docker build --platform=${platform.toString().trim()} -t llhttp_wasm_builder . --load`;
 
   console.log(`> ${cmd}\n\n`);
   execSync(cmd, { stdio: 'inherit' });
@@ -32,7 +33,10 @@ if (process.argv[2] === '--setup') {
 }
 
 if (process.argv[2] === '--docker') {
-  let cmd = `docker run --rm -it --platform=${platform.toString().trim()}`;
+  let cmd = `docker run --rm --platform=${platform.toString().trim()}`;
+  if (!IS_CI) {
+    cmd += ' -it';
+  }
   // Try to avoid root permission problems on compiled assets
   // when running on linux.
   // It will work flawessly if uid === gid === 1000

--- a/src/native/api.c
+++ b/src/native/api.c
@@ -57,29 +57,14 @@ static int wasm_on_headers_complete_wrap(llhttp_t* p) {
 }
 
 const llhttp_settings_t wasm_settings = {
-  wasm_on_message_begin,
-  wasm_on_url,
-  wasm_on_status,
-  NULL,
-  NULL,
-  wasm_on_header_field,
-  wasm_on_header_value,
-  NULL,
-  NULL,
-  wasm_on_headers_complete_wrap,
-  wasm_on_body,
-  wasm_on_message_complete,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
-  NULL,
+  .on_message_begin = wasm_on_message_begin,
+  .on_url = wasm_on_url,
+  .on_status = wasm_on_status,
+  .on_header_field = wasm_on_header_field,
+  .on_header_value = wasm_on_header_value,
+  .on_headers_complete = wasm_on_headers_complete_wrap,
+  .on_body = wasm_on_body,
+  .on_message_complete = wasm_on_message_complete,
 };
 
 


### PR DESCRIPTION
The current wasm build is broken because it's untested in CI. This PR fixes the issue and adds a wasm build.

(I can back out the artifact uploading if unwanted, but I'm hoping to follow up this PR with one to automate releases and add npm publishing.)