### PR TITLE
chore: use a configurable value for number of open Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}


### PR DESCRIPTION
This way, we can disable all dependabot PRs from private forks – I'm fed up with the flow of useless notifications coming from our nodejs-private org.

Refs: https://github.com/nodejs/node/pull/56427