### PR TITLE
chore: Fixed license path and CMake minimum version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.25.0)
 cmake_policy(SET CMP0069 NEW)
 
 project(llhttp VERSION _RELEASE_)

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ release: clean generate
 	sed s/_RELEASE_/$(RELEASE)/ CMakeLists.txt > release/CMakeLists.txt
 	cp -rf libllhttp.pc.in release/
 	cp -rf README.md release/
-	cp -rf LICENSE-MIT release/
+	cp -rf LICENSE release/
 
 github-release:
 	@echo "${RELEASE_V}" | grep -q -E "^v" || { echo "Please make sure version starts with \"v\"."; exit 1; }
@@ -74,7 +74,7 @@ postversion: release
 	git checkout release --
 	cp -rf release/* ./
 	rm -rf release
-	git add include src *.gyp *.gypi CMakeLists.txt README.md LICENSE-MIT libllhttp.pc.in
+	git add include src *.gyp *.gypi CMakeLists.txt README.md LICENSE libllhttp.pc.in
 	git commit -a -m "release: $(RELEASE)"
 	git tag "release/v$(RELEASE)"
 	git push && git push --tags


### PR DESCRIPTION
Fixes #564 and #542.