### PR TITLE
Fix aiohttp dev mode tests

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -59,6 +59,7 @@ jobs:
     - name: Run dev_mode tests
       env:
         COLOR: yes
+        PYTHONDEVMODE: 1
       run: >-
         PATH="${HOME}/.local/bin:${PATH}"
-        python -X dev -m pytest -m dev_mode tests/test_http_parser.py tests/test_web_functional.py
+        pytest -m dev_mode tests/test_http_parser.py tests/test_web_functional.py


### PR DESCRIPTION
Seems like the `-X dev` is suddenly not enabling dev mode correctly for some bizarre reason. Trying an alternative way to enable it.