### PR TITLE
chore: fix `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: !!int ${{secrets.OPEN_PR_LIMIT}}
 
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: !!int ${{secrets.OPEN_PR_LIMIT}}
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: !!int ${{secrets.OPEN_PR_LIMIT}}


### PR DESCRIPTION
It looks like the YAML parser needs some nudge to correctly parse the file for some reason.