### PR TITLE
build: add llhttp-specific prefix to CMake options.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,8 @@ endif()
 # Options
 #
 # Generic option
-option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so)" ON)
-option(BUILD_STATIC_LIBS "Build static libraries (.lib/.a)" OFF)
+option(LLHTTP_BUILD_SHARED_LIBS "Build shared libraries (.dll/.so)" ON)
+option(LLHTTP_BUILD_STATIC_LIBS "Build static libraries (.lib/.a)" OFF)
 
 # Source code
 set(LLHTTP_SOURCES
@@ -80,7 +80,7 @@ function(config_library target)
   )
 endfunction(config_library target)
 
-if(BUILD_SHARED_LIBS)
+if(LLHTTP_BUILD_SHARED_LIBS)
   add_library(llhttp_shared SHARED
       ${llhttp_src}
   )
@@ -88,11 +88,11 @@ if(BUILD_SHARED_LIBS)
   config_library(llhttp_shared)
 endif()
 
-if(BUILD_STATIC_LIBS)
+if(LLHTTP_BUILD_STATIC_LIBS)
   add_library(llhttp_static STATIC
       ${llhttp_src}
   )
-  if(BUILD_SHARED_LIBS)
+  if(LLHTTP_BUILD_SHARED_LIBS)
     add_library(llhttp::llhttp ALIAS llhttp_shared)
   else()
     add_library(llhttp::llhttp ALIAS llhttp_static)
@@ -113,6 +113,6 @@ message(STATUS "Project configure summary:")
 message(STATUS "")
 message(STATUS "  CMake build type .................: ${CMAKE_BUILD_TYPE}")
 message(STATUS "  Install prefix ...................: ${CMAKE_INSTALL_PREFIX}")
-message(STATUS "  Build shared library .............: ${BUILD_SHARED_LIBS}")
-message(STATUS "  Build static library .............: ${BUILD_STATIC_LIBS}")
+message(STATUS "  Build shared library .............: ${LLHTTP_BUILD_SHARED_LIBS}")
+message(STATUS "  Build static library .............: ${LLHTTP_BUILD_STATIC_LIBS}")
 message(STATUS "")


### PR DESCRIPTION
BUILD_SHARED_LIBS is now called LLHTTP_BUILD_SHARED_LIBS.

BUILD_STATIC_LIBS is now called LLHTTP_BUILD_STATIC_LIBS.

CMake options have global scope so there's the risk of conflict otherwise. For example, libcurl has a BUILD_STATIC_LIBS option too.

Documentation updates to be discussed.

See https://github.com/nodejs/llhttp/issues/647