### PR TITLE
Remove duplicate target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,7 @@ if(BUILD_STATIC_LIBS)
   add_library(llhttp_static STATIC
       ${llhttp_src}
   )
-  if(BUILD_SHARED_LIBS)
-    add_library(llhttp::llhttp ALIAS llhttp_shared)
-  else()
+  if(NOT BUILD_SHARED_LIBS)
     add_library(llhttp::llhttp ALIAS llhttp_static)
   endif()
   config_library(llhttp_static)


### PR DESCRIPTION
llhttp_shared is already set in line 87 when BUILD_SHARED_LIBS is true.

Fix #671.