### PR TITLE
Export map for shared library symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ endif()
 option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so)" ON)
 option(BUILD_STATIC_LIBS "Build static libraries (.lib/.a)" OFF)
 
+# Shared library versioning support
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libllhttp.map")
+
 # Source code
 set(LLHTTP_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/src/llhttp.c

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ release: clean generate
 	cp -rf src/common.gypi release/
 	sed s/_RELEASE_/$(RELEASE)/ CMakeLists.txt > release/CMakeLists.txt
 	cp -rf libllhttp.pc.in release/
+	cp -rf libllhttp.map release/
 	cp -rf README.md release/
 	cp -rf LICENSE release/
 

--- a/libllhttp.map
+++ b/libllhttp.map
@@ -1,0 +1,6 @@
+{
+	global:
+		*;
+	local:
+		llhttp__internal_*;
+};


### PR DESCRIPTION
This is an PoC for fixing https://github.com/nodejs/llhttp/issues/717.

It shouldn't be merged as-is, since it isn't cross-platform.