### PR TITLE
fix: update shell command built from environment values

### DIFF
--- a/bin/build_wasm.ts
+++ b/bin/build_wasm.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { copyFileSync, mkdirSync } from 'fs';
 import { join, resolve } from 'path';
 
@@ -59,28 +59,30 @@ try {
 execSync('npm run build', { cwd: WASM_SRC, stdio: 'inherit' });
 
 // Build wasm binary
-execSync(
-  `clang \
- --sysroot=/usr/share/wasi-sysroot \
- -target wasm32-unknown-wasi \
- -Ofast \
- -fno-exceptions \
- -fvisibility=hidden \
- -mexec-model=reactor \
- -Wl,-error-limit=0 \
- -Wl,-O3 \
- -Wl,--lto-O3 \
- -Wl,--strip-all \
- -Wl,--allow-undefined \
- -Wl,--export-dynamic \
- -Wl,--export-table \
- -Wl,--export=malloc \
- -Wl,--export=free \
- -Wl,--no-entry \
- ${join(WASM_SRC, 'build', 'c')}/*.c \
- ${join(WASM_SRC, 'src', 'native')}/*.c \
- -I${join(WASM_SRC, 'build')} \
- -o ${join(WASM_OUT, 'llhttp.wasm')}`,
+execFileSync(
+  'clang',
+  [
+    '--sysroot=/usr/share/wasi-sysroot',
+    '-target', 'wasm32-unknown-wasi',
+    '-Ofast',
+    '-fno-exceptions',
+    '-fvisibility=hidden',
+    '-mexec-model=reactor',
+    '-Wl,-error-limit=0',
+    '-Wl,-O3',
+    '-Wl,--lto-O3',
+    '-Wl,--strip-all',
+    '-Wl,--allow-undefined',
+    '-Wl,--export-dynamic',
+    '-Wl,--export-table',
+    '-Wl,--export=malloc',
+    '-Wl,--export=free',
+    '-Wl,--no-entry',
+    ...[`${join(WASM_SRC, 'build', 'c')}/*.c`],
+    ...[`${join(WASM_SRC, 'src', 'native')}/*.c`],
+    `-I${join(WASM_SRC, 'build')}`,
+    '-o', join(WASM_OUT, 'llhttp.wasm'),
+  ],
   { stdio: 'inherit' },
 );
 


### PR DESCRIPTION
https://github.com/nodejs/llhttp/blob/46bf88dff124ea7e1791be197fc4b84f15ceaee1/bin/build_wasm.ts#L62-L83


Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

fix the problem, we should avoid constructing the shell command as a single string with interpolated paths. Instead, we should use `execFileSync` from the `child_process` module, which allows us to pass the command and its arguments as an array, ensuring that each argument is properly escaped and interpreted as a literal value by the underlying process, not by the shell. This prevents spaces or special characters in paths from causing misinterpretation or command injection.

Specifically, in `bin/build_wasm.ts`, replace the `execSync` call on lines 62-85 with an `execFileSync` call.  
- Split the `clang` command and its arguments into an array, using the resolved paths as array elements.
- Import `execFileSync` from `child_process`.
- Remove the use of template literals for the command string.