### PR TITLE
chore: Pin python version to fix aiohttp regression tests

### DIFF
--- a/.github/workflows/aiohttp.yml
+++ b/.github/workflows/aiohttp.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
       with:
-        python-version: 3.x
+        python-version: 3.13
         cache: 'pip'
         cache-dependency-path: 'requirements/*.txt'
     - name: Provision the dev env


### PR DESCRIPTION
The tests fail due to a Python version vs Aiohttp dependency incompatibility in Python 3.14+, which breaks the initial Aiohttp project setup. From our side though, I think there's no issue with simply testing with Python 3.13 anyway, and having a pinned version gives more reproducible tests, so it's actually quite helpful in itself.